### PR TITLE
feat(hobbyGroup): added pagination to the get endpoints

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
@@ -1,6 +1,8 @@
 package cloudflight.integra.backend.hobbyGroup;
 
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroupDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,13 +21,13 @@ public class HobbyGroupController {
     }
 
     @GetMapping
-    public List<HobbyGroupDto> getAll() {
-        return service.getAll().stream().map(mapper::toDto).toList();
+    public List<Page<HobbyGroupDto>> getAll(Pageable pageable) {
+        return List.of(service.getAll(pageable).map(mapper::toDto));
     }
 
     @GetMapping("/filter")
-    public List<HobbyGroupDto> filterByName(@RequestParam String name) {
-        return service.filterByName(name).stream().map(mapper::toDto).toList();
+    public List<Page<HobbyGroupDto>> filterByName(@RequestParam String name, Pageable pageable) {
+        return List.of(service.filterByName(name, pageable).map(mapper::toDto));
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupRepository.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupRepository.java
@@ -1,11 +1,13 @@
 package cloudflight.integra.backend.hobbyGroup;
 
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
 public interface HobbyGroupRepository extends JpaRepository<HobbyGroup, UUID> {
-
+    Page<HobbyGroup> findByNameContainingIgnoreCase(String name, Pageable pageable);
 }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
@@ -1,22 +1,24 @@
 package cloudflight.integra.backend.hobbyGroup;
 
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 public class HobbyGroupService {
     private final HobbyGroupRepository repository;
 
+
     public HobbyGroupService(HobbyGroupRepository repository) {
         this.repository = repository;
+
     }
 
-    public List<HobbyGroup> getAll() {
-        return repository.findAll();
+    public Page<HobbyGroup> getAll(Pageable pageable) {
+        return repository.findAll(pageable);
     }
 
     public Optional<HobbyGroup> getById(UUID id) {
@@ -43,12 +45,8 @@ public class HobbyGroupService {
         return false;
     }
 
-    public List<HobbyGroup> filterByName(String containedString) {
-        return repository.findAll()
-            .stream()
-            .filter(group -> group.getName() != null &&
-                group.getName().toLowerCase().contains(containedString.toLowerCase()))
-            .collect(Collectors.toList());
+    public Page<HobbyGroup> filterByName(String containedString, Pageable pageable) {
+        return repository.findByNameContainingIgnoreCase(containedString, pageable);
     }
 
 }


### PR DESCRIPTION
I modified the get methods in the controller (apart from the getByID) to accept a Pageable as parameter and return a Page of entities. I also modified the get functions in the service to return pages of hobbyGroupDTOs and added a mapper to the service. I also modified the filter function in the service so it moves the logic to the repository

Refs: #23