### PR TITLE
feat(general): make all services behave the same

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/event/EventController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/event/EventController.java
@@ -49,8 +49,7 @@ public class EventController {
 
     @GetMapping("/{id}")
     public EventDto getById(@PathVariable UUID id) {
-        return service.getById(id)
-            .map(mapper::toDto).orElse(null);
+        return mapper.toDto(service.getById(id));
     }
 
     @GetMapping("/location/{locationId}")
@@ -60,16 +59,16 @@ public class EventController {
 
     @PostMapping
     public EventDto create(@RequestBody EventDto dto) {
-        Location location = locationService.getById(dto.locationId()).orElseThrow();
-        HobbyGroup hobbyGroupById = hobbyGroupService.getById(dto.hobbyGroupId()).orElseThrow();
+        Location location = locationService.getById(dto.locationId());
+        HobbyGroup hobbyGroupById = hobbyGroupService.getById(dto.hobbyGroupId());
         return mapper.toDto(service.create(mapper.toEntity(dto, location, hobbyGroupById)));
     }
 
     @PutMapping("/{id}")
     public EventDto update(@PathVariable UUID id, @RequestBody EventDto dto) {
-        HobbyGroup hobbyGroupById = hobbyGroupService.getById(dto.hobbyGroupId()).orElseThrow();
-        Location location = locationService.getById(dto.locationId()).orElseThrow();
-        return service.update(id, mapper.toEntity(dto, location, hobbyGroupById)).map(mapper::toDto).orElse(null);
+        HobbyGroup hobbyGroupById = hobbyGroupService.getById(dto.hobbyGroupId());
+        Location location = locationService.getById(dto.locationId());
+        return mapper.toDto(service.update(id, mapper.toEntity(dto, location, hobbyGroupById)));
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/cloudflight/integra/backend/event/EventService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/event/EventService.java
@@ -1,13 +1,13 @@
 package cloudflight.integra.backend.event;
 
 import cloudflight.integra.backend.event.model.Event;
-import cloudflight.integra.backend.exceptions.ObjectNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
@@ -18,41 +18,53 @@ public class EventService {
         this.repository = repository;
     }
 
+    @Transactional(readOnly = true)
     public Page<Event> getAll(Pageable pageable) {
         return repository.findAll(pageable);
     }
 
+    @Transactional(readOnly = true)
     public Page<Event> getAllByTime(LocalDateTime after, Pageable pageable) {
         return repository.findAllByStartTimeAfter(after, pageable);
     }
 
-    public Optional<Event> getById(UUID id) {
-        if (repository.findById(id).isEmpty()) {
-            throw new ObjectNotFoundException("Event not found");
-        }
-        return repository.findById(id);
+    @Transactional(readOnly = true)
+    public Event getById(UUID id) {
+        return repository.findById(id).orElseThrow();
     }
 
+    @Transactional
     public Event create(Event event) {
+        event.setId(null);
         return repository.save(event);
     }
 
-    public Optional<Event> update(UUID id, Event event) {
+    @Transactional
+    public Event update(UUID id, Event event) {
 
-        if (repository.findById(id).isPresent()) {
-            event.setId(id);
-            return Optional.of(repository.save(event));
-        } else throw new ObjectNotFoundException("Event not found");
+        Event oldEvent = repository.findById(id).orElseThrow();
+
+        oldEvent.setEndTime(event.getEndTime());
+        oldEvent.setStartTime(event.getStartTime());
+        oldEvent.setHobbyGroup(event.getHobbyGroup());
+        oldEvent.setLocation(event.getLocation());
+        oldEvent.setTitle(event.getTitle());
+
+        return oldEvent;
     }
 
-    public void delete(UUID id) {
-        repository.deleteById(id);
+    @Transactional
+    public boolean delete(UUID id) {
+        Event event = repository.findById(id).orElseThrow();
+        repository.deleteById(event.getId());
+        return true;
     }
 
+    @Transactional(readOnly = true)
     public Page<Event> getByLocationId(UUID locationId, Pageable pageable) {
         Page<Event> events = repository.findAllByLocationId(locationId, pageable);
-        if(events.isEmpty()){
-            throw new ObjectNotFoundException("There is not Event found at this location.");
+        if (events.isEmpty()) {
+            throw new NoSuchElementException("There is not Event found at this location.");
         }
         return events;
     }

--- a/backend/src/main/java/cloudflight/integra/backend/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/cloudflight/integra/backend/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package cloudflight.integra.backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException elementException) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(elementException.getMessage());
+    }
+}

--- a/backend/src/main/java/cloudflight/integra/backend/exceptions/ObjectNotFoundException.java
+++ b/backend/src/main/java/cloudflight/integra/backend/exceptions/ObjectNotFoundException.java
@@ -1,7 +1,0 @@
-package cloudflight.integra.backend.exceptions;
-
-public class ObjectNotFoundException extends RuntimeException {
-    public ObjectNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
@@ -32,7 +32,7 @@ public class HobbyGroupController {
 
     @GetMapping("/{id}")
     public HobbyGroupDto getById(@PathVariable UUID id) {
-        return service.getById(id).map(mapper::toDto).orElse(null);
+        return mapper.toDto(service.getById(id));
     }
 
 
@@ -43,7 +43,7 @@ public class HobbyGroupController {
 
     @PutMapping("/{id}")
     public HobbyGroupDto update(@PathVariable UUID id, @RequestBody HobbyGroupDto groupDto) {
-        return service.update(id, mapper.toEntity(groupDto)).map(mapper::toDto).orElse(null);
+        return mapper.toDto(service.update(id, mapper.toEntity(groupDto)));
 
     }
 

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
@@ -1,10 +1,13 @@
 package cloudflight.integra.backend.hobbyGroup;
 
+
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import java.util.Optional;
+
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
@@ -17,34 +20,42 @@ public class HobbyGroupService {
 
     }
 
+    @Transactional(readOnly = true)
     public Page<HobbyGroup> getAll(Pageable pageable) {
         return repository.findAll(pageable);
     }
 
-    public Optional<HobbyGroup> getById(UUID id) {
-        return repository.findById(id);
+    @Transactional(readOnly = true)
+    public HobbyGroup getById(UUID id) {
+        return repository.findById(id).orElseThrow();
     }
 
+    @Transactional
     public HobbyGroup create(HobbyGroup group) {
+        group.setId(null);
         return repository.save(group);
     }
 
-    public Optional<HobbyGroup> update(UUID id, HobbyGroup group) {
-        if (repository.findById(id).isPresent()) {
-            group.setId(id);
-            return Optional.of(repository.save(group));
-        }
-        return Optional.empty();
+    @Transactional
+    public HobbyGroup update(UUID id, HobbyGroup newGroup) {
+
+        HobbyGroup oldGroup = repository.findById(id).orElseThrow();
+        oldGroup.setName(newGroup.getName());
+        oldGroup.setDescription(newGroup.getDescription());
+        oldGroup.setRadiusKm(newGroup.getRadiusKm());
+
+        return oldGroup;
     }
 
+    @Transactional
     public boolean delete(UUID id) {
         if (repository.findById(id).isPresent()) {
             repository.deleteById(id);
             return true;
-        }
-        return false;
+        } else throw new NoSuchElementException();
     }
 
+    @Transactional(readOnly = true)
     public Page<HobbyGroup> filterByName(String containedString, Pageable pageable) {
         return repository.findByNameContainingIgnoreCase(containedString, pageable);
     }

--- a/backend/src/main/java/cloudflight/integra/backend/location/LocationController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/location/LocationController.java
@@ -34,7 +34,7 @@ public class LocationController {
 
     @GetMapping("/{id}")
     public LocationDto getById(@PathVariable UUID id) {
-        return locationService.getById(id).map(locationMapper::toDto).orElse(null);
+        return locationMapper.toDto(locationService.getById(id));
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/cloudflight/integra/backend/location/LocationService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/location/LocationService.java
@@ -4,8 +4,8 @@ import cloudflight.integra.backend.location.model.Location;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -16,22 +16,29 @@ public class LocationService {
         this.repository = repository;
     }
 
+    @Transactional(readOnly = true)
     public Page<Location> getAll(Pageable pageable) {
         return repository.findAll(pageable);
     }
 
-    public Optional<Location> getById(UUID id) {
-        return repository.findById(id);
+    @Transactional(readOnly = true)
+    public Location getById(UUID id) {
+        return repository.findById(id).orElseThrow();
     }
 
+    @Transactional
     public Location create(Location location) {
         return repository.save(location);
     }
 
-    public void delete(UUID id) {
-        repository.deleteById(id);
+    @Transactional(readOnly = true)
+    public boolean delete(UUID id) {
+        Location location = repository.findById(id).orElseThrow();
+        repository.deleteById(location.getId());
+        return true;
     }
 
+    @Transactional(readOnly = true)
     public Page<Location> getByName(String name, Pageable pageable) {
         return repository.findByNameContainingIgnoreCase(name, pageable);
     }

--- a/backend/src/main/java/cloudflight/integra/backend/systemFeedback/SystemFeedbackController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/systemFeedback/SystemFeedbackController.java
@@ -30,7 +30,7 @@ public class SystemFeedbackController {
 
     @GetMapping("/{id}")
     public SystemFeedbackDTO getById(@PathVariable UUID id) {
-        return service.getById(id).map(mapper::toDto).orElse(null);
+        return mapper.toDto(service.getById(id));
     }
 
     @PostMapping
@@ -40,7 +40,7 @@ public class SystemFeedbackController {
 
     @PutMapping("/{id}")
     public SystemFeedbackDTO update(@PathVariable UUID id, @RequestBody SystemFeedbackDTO dto) {
-        return service.update(id, mapper.toEntity(dto)).map(mapper::toDto).orElse(null);
+        return mapper.toDto(service.update(id, mapper.toEntity(dto)));
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/cloudflight/integra/backend/systemFeedback/SystemFeedbackService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/systemFeedback/SystemFeedbackService.java
@@ -1,17 +1,17 @@
 package cloudflight.integra.backend.systemFeedback;
 
 import cloudflight.integra.backend.systemFeedback.model.SystemFeedback;
-import jakarta.transaction.Transactional;
+
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 @Service
-@Transactional
 public class SystemFeedbackService {
 
     private final SystemFeedbackRepository repository;
@@ -19,17 +19,23 @@ public class SystemFeedbackService {
     public SystemFeedbackService(SystemFeedbackRepository repository) {
         this.repository = repository;
     }
+
+    @Transactional(readOnly = true)
     public Page<SystemFeedback> getAllPaginated(Pageable pageable) {
         return repository.findAll(pageable);
     }
+
+    @Transactional(readOnly = true)
     public List<SystemFeedback> getAll() {
         return repository.findAll();
     }
 
-    public Optional<SystemFeedback> getById(UUID id) {
-        return repository.findById(id);
+    @Transactional(readOnly = true)
+    public SystemFeedback getById(UUID id) {
+        return repository.findById(id).orElseThrow();
     }
 
+    @Transactional
     public SystemFeedback create(SystemFeedback systemFeedback) {
         if (systemFeedback.getCreatedAt() == null) {
             systemFeedback.setCreatedAt(LocalDateTime.now());
@@ -37,20 +43,25 @@ public class SystemFeedbackService {
         return repository.save(systemFeedback);
     }
 
-    public Optional<SystemFeedback> update(UUID id, SystemFeedback systemFeedback) {
-        if (repository.findById(id).isPresent()) {
-            systemFeedback.setId(id);
-            return Optional.of(repository.save(systemFeedback));
-        }
-        return Optional.empty();
+    @Transactional
+    public SystemFeedback update(UUID id, SystemFeedback newSystemFeedback) {
+        SystemFeedback oldFeedback = repository.findById(id).orElseThrow();
+
+        oldFeedback.setCreatedAt(newSystemFeedback.getCreatedAt());
+        oldFeedback.setEmail(newSystemFeedback.getEmail());
+        oldFeedback.setMessage(newSystemFeedback.getMessage());
+
+        return oldFeedback;
+
     }
 
+    @Transactional
     public boolean delete(UUID id) {
         if (repository.findById(id).isPresent()) {
             repository.deleteById(id);
             return true;
         }
-        return false;
+        else throw new NoSuchElementException();
     }
 
 }

--- a/backend/src/main/java/cloudflight/integra/backend/tag/TagController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/tag/TagController.java
@@ -26,7 +26,7 @@ public class TagController {
 
     @GetMapping("/{id}")
     public TagDto getById(@PathVariable Long id) {
-        return this.service.getById(id).map(this.mapper::toDto).orElse(null);
+        return mapper.toDto(this.service.getById(id));
     }
 
     @GetMapping("/normalized/{label}")
@@ -44,7 +44,7 @@ public class TagController {
 
     @PutMapping("/{id}")
     public TagDto update(@PathVariable Long id, @RequestBody TagDto dto) {
-        return this.service.update(id, this.mapper.toEntity(dto)).map(this.mapper::toDto).orElse(null);
+        return mapper.toDto(this.service.update(id, this.mapper.toEntity(dto)));
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/cloudflight/integra/backend/tag/TagService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/tag/TagService.java
@@ -4,8 +4,8 @@ import cloudflight.integra.backend.tag.model.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 
 @Service
 public class TagService {
@@ -15,10 +15,13 @@ public class TagService {
         this.repository = repository;
     }
 
+    @Transactional(readOnly = true)
     public Page<Tag> getAll(Pageable pageable) { return this.repository.findAll(pageable); }
 
-    public Optional<Tag> getById(Long id) { return this.repository.findById(id); }
+    @Transactional(readOnly = true)
+    public Tag getById(Long id) { return this.repository.findById(id).orElseThrow(); }
 
+    @Transactional(readOnly = true)
     public Page<Tag> getByNormalizedLabel(String normalizedLabel, Pageable pageable) {
         return this.repository.findByNormalizedLabel(normalizedLabel, pageable);
     }
@@ -27,23 +30,25 @@ public class TagService {
         return label.trim().toLowerCase();
     }
 
+    @Transactional
     public Tag create(Tag tag) {
         tag.setNormalizedLabel(this.generateNormalizedLabel(tag.getLabel()));
         return this.repository.save(tag);
     }
 
-    public Optional<Tag> update(Long id, Tag newTag) {
-        if (this.repository.findById(id).isPresent()) {
-            newTag.setId(id);
-            newTag.setNormalizedLabel(this.generateNormalizedLabel(newTag.getLabel()));
+    @Transactional
+    public Tag update(Long id, Tag newTag) {
+        Tag oldTag = repository.findById(id).orElseThrow();
 
-            return Optional.of(this.repository.save(newTag));
-        }
-
-        return Optional.empty();
+        oldTag.setLabel(newTag.getLabel());
+        oldTag.setNormalizedLabel(newTag.getNormalizedLabel());
+        return oldTag;
     }
 
-    public void delete(Long id) {
-        this.repository.deleteById(id);
+    @Transactional
+    public boolean delete(Long id) {
+        Tag tag = repository.findById(id).orElseThrow();
+        this.repository.deleteById(tag.getId());
+        return true;
     }
 }

--- a/frontend/.postcssrc.json
+++ b/frontend/.postcssrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": {
-    "@tailwindcss/postcss": {}
+    "plugins": {
+      "@tailwindcss/postcss": {}
   }
 }


### PR DESCRIPTION
Modified all the services so they would not pass unto the controller Optional objects and changed the controllers accordingly. Modified the services, so in case an object does not exist it throws NoSuchElementException (either manually, or through Optional::orElseThrow). Modified the update in the services for Hobby group, Tag, Event and System Feedback. Added the @Transactional annotation for all methods in the service.

Refs: #60