### PR TITLE
JPA(hobbyGroup): linked user to hobby group through owner id and members table

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
@@ -2,15 +2,18 @@ package cloudflight.integra.backend.hobbyGroup;
 
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroupDto;
+import cloudflight.integra.backend.tag.TagService;
+import cloudflight.integra.backend.user.UserService;
+import cloudflight.integra.backend.user.model.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import cloudflight.integra.backend.tag.TagService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
 
 import java.util.UUID;
 
@@ -21,11 +24,18 @@ public class HobbyGroupController {
     private final HobbyGroupService hobbyGroupService;
     private final TagService tagService;
     private final HobbyGroupMapper mapper;
+    private final UserService userService;
 
-    public HobbyGroupController(HobbyGroupService service, TagService tagService, HobbyGroupMapper mapper) {
+    public HobbyGroupController(
+        HobbyGroupService service,
+        TagService tagService,
+        HobbyGroupMapper mapper,
+        UserService userService
+    ) {
         this.hobbyGroupService = service;
         this.tagService = tagService;
         this.mapper = mapper;
+        this.userService = userService;
     }
 
     @Operation(
@@ -94,33 +104,42 @@ public class HobbyGroupController {
                     mediaType = "application/json",
                     schema = @Schema(implementation = HobbyGroupDto.class))),
         })
-    public HobbyGroupDto create(@RequestBody HobbyGroupDto groupDto) {
+    public HobbyGroupDto create(
+        @RequestBody HobbyGroupDto groupDto,
+        @AuthenticationPrincipal UserDetails currentUser
+    ) {
+        User owner = userService.getByUsername(currentUser.getUsername());
         HobbyGroup createHobbyGroup = hobbyGroupService.create(mapper.toEntity(
             groupDto,
-            tagService.getTagsFromIds(groupDto.tagIds())));
-
+            tagService.getTagsFromIds(groupDto.tagIds()),
+            owner)
+        );
         return mapper.toDto(createHobbyGroup, groupDto.tagIds());
     }
 
     @PutMapping("/{id}")
     @Operation(
-        summary = "Update an existing Hobby Group",
-        operationId = "updateHobbyGroup",
+        summary = "Add an hobbyGroup to the repository",
+        operationId = "createNewHobbyGroup",
         responses = {
-            @ApiResponse(responseCode = "200",
-                description = "Group updated successfully",
+            @ApiResponse(
+                responseCode = "200",
+                description = "HobbyGroup added successfully; returns the added hobbyGroup",
                 content =
                 @Content(
                     mediaType = "application/json",
                     schema = @Schema(implementation = HobbyGroupDto.class))),
-            @ApiResponse(responseCode = "404",
-                description = "Group not found")
         })
-
-    public HobbyGroupDto update(@PathVariable UUID id, @RequestBody HobbyGroupDto groupDto) {
+    public HobbyGroupDto update(
+        @PathVariable UUID id,
+        @RequestBody HobbyGroupDto groupDto,
+        @AuthenticationPrincipal UserDetails currentUser
+    ) {
+        User owner = userService.getByUsername(currentUser.getUsername());
         HobbyGroup updateHobbyGroup = hobbyGroupService.update(id, mapper.toEntity(
             groupDto,
-            tagService.getTagsFromIds(groupDto.tagIds())));
+            tagService.getTagsFromIds(groupDto.tagIds()),
+            owner));
 
         return mapper.toDto(updateHobbyGroup, groupDto.tagIds());
     }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupMapper.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupMapper.java
@@ -3,19 +3,32 @@ package cloudflight.integra.backend.hobbyGroup;
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroupDto;
 import cloudflight.integra.backend.tag.model.Tag;
+import cloudflight.integra.backend.user.model.User;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class HobbyGroupMapper {
 
     public HobbyGroupDto toDto(HobbyGroup group, List<Long> tagIds) {
-        return new HobbyGroupDto(group.getId(), group.getName(), group.getDescription(), group.getRadiusKm(), tagIds);
+        return new HobbyGroupDto(group.getId(),
+            group.getName(),
+            group.getDescription(),
+            group.getRadiusKm(),
+            tagIds,
+            group.getOwner().getId(),
+            group.getMembers().stream().map(User::getId).collect(Collectors.toSet()));
     }
 
-    public HobbyGroup toEntity(HobbyGroupDto groupDto, List<Tag> tags) {
-        return new HobbyGroup(groupDto.id(), groupDto.name(), groupDto.description(), groupDto.radiusKm(), tags);
+    public HobbyGroup toEntity(HobbyGroupDto groupDto, List<Tag> tags, User owner) {
+        return new HobbyGroup(groupDto.id(),
+            groupDto.name(),
+            groupDto.description(),
+            groupDto.radiusKm(),
+            tags,
+            owner);
     }
 
 }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupRepository.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
 import java.util.UUID;
 
 @Repository

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroup.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroup.java
@@ -1,9 +1,12 @@
 package cloudflight.integra.backend.hobbyGroup.model;
 
 import cloudflight.integra.backend.tag.model.Tag;
+import cloudflight.integra.backend.user.model.User;
 import jakarta.persistence.*;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -18,17 +21,38 @@ public class HobbyGroup {
     @ManyToMany
     @JoinTable(
         name = "Group_Tags",
-        joinColumns = { @JoinColumn(name = "hobby_group_id") },
-        inverseJoinColumns = { @JoinColumn(name = "tag_id") }
+        joinColumns = {@JoinColumn(name = "hobby_group_id")},
+        inverseJoinColumns = {@JoinColumn(name = "tag_id")}
     )
     private List<Tag> tags;
 
-    public HobbyGroup(UUID id, String name, String description, double radiusKm, List<Tag> tags) {
+    @ManyToOne
+    @JoinColumn(name = "owner_id")
+    private User owner;
+
+    @ManyToMany
+    @JoinTable(
+        name = "group_members",
+        joinColumns = @JoinColumn(name = "hobby_group_id"),
+        inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private final Set<User> members = new HashSet<>();
+
+
+    public HobbyGroup(
+        UUID id,
+        String name,
+        String description,
+        double radiusKm,
+        List<Tag> tags,
+        User owner
+    ) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.radiusKm = radiusKm;
         this.tags = tags;
+        this.owner = owner;
     }
 
     public HobbyGroup() {
@@ -53,6 +77,14 @@ public class HobbyGroup {
 
     public List<Tag> getTags() {
         return tags;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public Set<User> getMembers() {
+        return members;
     }
 
     public void setId(UUID id) {

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroupDto.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroupDto.java
@@ -1,7 +1,16 @@
 package cloudflight.integra.backend.hobbyGroup.model;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
-public record HobbyGroupDto(UUID id, String name, String description, double radiusKm, List<Long> tagIds) {
+public record HobbyGroupDto(
+    UUID id,
+    String name,
+    String description,
+    double radiusKm,
+    List<Long> tagIds,
+    UUID ownerID,
+    Set<UUID> memberIds
+) {
 }

--- a/backend/src/main/java/cloudflight/integra/backend/user/UserService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/UserService.java
@@ -42,4 +42,8 @@ public class UserService implements UserDetailsService {
         user.getTags().addAll(tags);
         userRepository.save(user);
     }
+
+    public User getByUsername(String username) {
+        return userRepository.findByUsername(username);
+    }
 }


### PR DESCRIPTION

Added the owner id to hobby groups table and created a many to many table for the hobby groups and the users (the members table). Modified the hobby group entity by adding the UUID of the user-owner and by adding the list of members. Altered the hobby group DTO and the hobby group controller accordingly

Refs: #19