### PR TITLE
refactor(hobbyGroup): remove like button from hobby group card

### DIFF
--- a/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.html
+++ b/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.html
@@ -18,7 +18,6 @@
             </div>
         </div>
         <div class="flex gap-4 mt-2 -mb-4">
-            <p-button label="Like" icon="pi pi-heart" variant="text"/>
             <p-button label="Join" icon="pi pi-users" variant="text"/>
         </div>
     </ng-template>


### PR DESCRIPTION
Removed like button from hobby group card. It had no endpoints related to it, so nothing else to remove.

Refs: 88