### PR TITLE
feat(hobbyGroup): hobby group join/leave and delete actions

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/exceptions/AlreadyMemberOfThisHobbyGroupException.java
+++ b/backend/src/main/java/cloudflight/integra/backend/exceptions/AlreadyMemberOfThisHobbyGroupException.java
@@ -1,0 +1,6 @@
+package cloudflight.integra.backend.exceptions;
+
+public class AlreadyMemberOfThisHobbyGroupException extends RuntimeException {
+    public AlreadyMemberOfThisHobbyGroupException(String s) {
+    }
+}

--- a/backend/src/main/java/cloudflight/integra/backend/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/cloudflight/integra/backend/exceptions/GlobalExceptionHandler.java
@@ -13,4 +13,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException elementException) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(elementException.getMessage());
     }
+    @ExceptionHandler(AlreadyMemberOfThisHobbyGroupException.class)
+    public ResponseEntity<String> handleAlreadyMemberOfThisHobbyGroupException(
+        AlreadyMemberOfThisHobbyGroupException alreadyMemberOfThisHobbyGroupException)
+    { return ResponseEntity.status(HttpStatus.CONFLICT).body(alreadyMemberOfThisHobbyGroupException.getMessage());}
+
+    @ExceptionHandler(NotMemberOfHobbyGroupException.class)
+    public ResponseEntity<String> handleNotMemberOfHobbyGroupException(
+        NotMemberOfHobbyGroupException notMemberOfHobbyGroupException)
+    { return ResponseEntity.status(HttpStatus.CONFLICT).body(notMemberOfHobbyGroupException.getMessage());}
+
 }

--- a/backend/src/main/java/cloudflight/integra/backend/exceptions/NotMemberOfHobbyGroupException.java
+++ b/backend/src/main/java/cloudflight/integra/backend/exceptions/NotMemberOfHobbyGroupException.java
@@ -1,0 +1,6 @@
+package cloudflight.integra.backend.exceptions;
+
+public class NotMemberOfHobbyGroupException extends RuntimeException {
+    public NotMemberOfHobbyGroupException(String s) {
+    }
+}

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
@@ -157,4 +157,43 @@ public class HobbyGroupController {
         hobbyGroupService.delete(id);
     }
 
+    @PostMapping("/{id}/join")
+    @Operation(
+        summary = "Add the current user to the hobbyGroup",
+        operationId = "joinHobbyGroup",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "HobbyGroup was joined successfully;",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = HobbyGroupDto.class))),
+            @ApiResponse(
+                responseCode = "409",
+                description = "User is already a member")
+        })
+    public HobbyGroupDto joinHobbyGroup(@PathVariable UUID id, @AuthenticationPrincipal UserDetails userDetails) {
+        User newMember = userService.getByUsername(userDetails.getUsername());
+        HobbyGroup updatedHobbyGroup = hobbyGroupService.addNewMemberToHobbyGroup(newMember, id);
+        return mapper.toDto(updatedHobbyGroup, tagService.getIdsFromTags(updatedHobbyGroup.getTags()));
+    }
+
+    @DeleteMapping("/{id}/leave")
+    @Operation(
+        summary = "Leave  Hobby Group",
+        operationId = "leaveHobbyGroup",
+        responses = {
+            @ApiResponse(
+                responseCode = "409",
+                description = "User was not a member",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = HobbyGroupDto.class)))
+        }
+    )
+    public HobbyGroupDto leaveHobbyGroup(@PathVariable UUID id, @AuthenticationPrincipal UserDetails userDetails) {
+        User oldMember = userService.getByUsername(userDetails.getUsername());
+        HobbyGroup updatedHobbyGroup = hobbyGroupService.deleteMemberFromHobbyGroup(oldMember, id);
+        return mapper.toDto(updatedHobbyGroup, tagService.getIdsFromTags(updatedHobbyGroup.getTags()));
+    }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupMapper.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupMapper.java
@@ -19,7 +19,7 @@ public class HobbyGroupMapper {
             group.getRadiusKm(),
             tagIds,
             group.getOwner().getId(),
-            group.getMembers().stream().map(User::getId).collect(Collectors.toSet()));
+            group.getMembers().stream().map(User::getId).collect(Collectors.toList()));
     }
 
     public HobbyGroup toEntity(HobbyGroupDto groupDto, List<Tag> tags, User owner) {

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
@@ -1,7 +1,10 @@
 package cloudflight.integra.backend.hobbyGroup;
 
 
+import cloudflight.integra.backend.exceptions.AlreadyMemberOfThisHobbyGroupException;
+import cloudflight.integra.backend.exceptions.NotMemberOfHobbyGroupException;
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
+import cloudflight.integra.backend.user.model.User;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -60,4 +63,23 @@ public class HobbyGroupService {
         return repository.findByNameContainingIgnoreCase(containedString, pageable);
     }
 
+    @Transactional
+    public HobbyGroup addNewMemberToHobbyGroup(User newMember, UUID hobbyGroupId){
+        HobbyGroup hobbyGroup = repository.findById(hobbyGroupId).orElseThrow();
+        if (hobbyGroup.getMembers().contains(newMember))
+            throw new AlreadyMemberOfThisHobbyGroupException("The user is already part of this group");
+        hobbyGroup.getMembers().add(newMember);
+        repository.save(hobbyGroup);
+        return hobbyGroup;
+    }
+
+    @Transactional
+    public HobbyGroup deleteMemberFromHobbyGroup(User oldMember, UUID hobbyGroupId ){
+        HobbyGroup hobbyGroup = repository.findById(hobbyGroupId).orElseThrow();
+        if (!hobbyGroup.getMembers().contains(oldMember))
+            throw new NotMemberOfHobbyGroupException("The user is not part of this group");
+        hobbyGroup.getMembers().remove(oldMember);
+        repository.save(hobbyGroup);
+        return hobbyGroup;
+    }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroup.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroup.java
@@ -4,10 +4,7 @@ import cloudflight.integra.backend.tag.model.Tag;
 import cloudflight.integra.backend.user.model.User;
 import jakarta.persistence.*;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Entity
 public class HobbyGroup {
@@ -36,7 +33,7 @@ public class HobbyGroup {
         joinColumns = @JoinColumn(name = "hobby_group_id"),
         inverseJoinColumns = @JoinColumn(name = "user_id")
     )
-    private final Set<User> members = new HashSet<>();
+    private final List<User> members = new LinkedList<>();
 
 
     public HobbyGroup(
@@ -53,6 +50,7 @@ public class HobbyGroup {
         this.radiusKm = radiusKm;
         this.tags = tags;
         this.owner = owner;
+        this.members.add(owner);
     }
 
     public HobbyGroup() {
@@ -83,7 +81,7 @@ public class HobbyGroup {
         return owner;
     }
 
-    public Set<User> getMembers() {
+    public List<User> getMembers() {
         return members;
     }
 

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroupDto.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroupDto.java
@@ -1,7 +1,6 @@
 package cloudflight.integra.backend.hobbyGroup.model;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 public record HobbyGroupDto(
@@ -11,6 +10,6 @@ public record HobbyGroupDto(
     double radiusKm,
     List<Long> tagIds,
     UUID ownerID,
-    Set<UUID> memberIds
+    List<UUID> memberIds
 ) {
 }

--- a/backend/src/main/java/cloudflight/integra/backend/user/UserController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/UserController.java
@@ -1,8 +1,16 @@
 package cloudflight.integra.backend.user;
 
 import cloudflight.integra.backend.tag.TagService;
+import cloudflight.integra.backend.user.model.User;
+import cloudflight.integra.backend.user.model.UserDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,10 +21,12 @@ import java.util.List;
 public class UserController {
     private final UserService userService;
     private final TagService tagService;
+    private final UserMapper userMapper;
 
-    public UserController(UserService userService, TagService tagService) {
+    public UserController(UserService userService, TagService tagService, UserMapper userMapper) {
         this.userService = userService;
         this.tagService = tagService;
+        this.userMapper = userMapper;
     }
 
     @PutMapping("/users/{username}/tags")
@@ -28,5 +38,25 @@ public class UserController {
         } catch (UsernameNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
+    }
+
+    @GetMapping("/users/me")
+    @Operation(
+        summary = "Get the information from the user",
+        operationId = "getUserInformation",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = UserDto.class))),
+        })
+    public ResponseEntity<UserDto> getCurrentUser(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        User user = userService.getByUsername(userDetails.getUsername());
+        return ResponseEntity.ok(userMapper.toDto(user));
     }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/user/UserMapper.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/UserMapper.java
@@ -1,0 +1,21 @@
+package cloudflight.integra.backend.user;
+
+import cloudflight.integra.backend.tag.model.Tag;
+import cloudflight.integra.backend.user.model.User;
+import cloudflight.integra.backend.user.model.UserDto;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+@Component
+public class UserMapper {
+
+    public UserDto toDto(User user){
+        return new UserDto(user.getId(),
+            user.getUsername(),
+            user.getEmail(),
+            user.getRole(),
+            user.getTags().stream().map(Tag::getId).collect(Collectors.toList()));
+    }
+
+}

--- a/backend/src/main/java/cloudflight/integra/backend/user/model/User.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/model/User.java
@@ -5,6 +5,7 @@ import cloudflight.integra.backend.user.Role;
 import jakarta.persistence.*;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -84,5 +85,17 @@ public class User {
 
     public void setTags(List<Tag> tags) {
         this.tags = tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User user)) return false;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/user/model/UserDto.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/model/UserDto.java
@@ -3,9 +3,10 @@ package cloudflight.integra.backend.user.model;
 import cloudflight.integra.backend.user.Role;
 
 import java.util.List;
+import java.util.UUID;
 
-public record UserDto(String username, String email, String password, Role role, List<Long> tagIds) {
-    public UserDto(String username, String email, String password) {
-        this(username, email, password, null, null);
+public record UserDto(UUID id, String username, String email, Role role, List<Long> tagIds) {
+    public UserDto(UUID id ,String username, String email) {
+        this(id, username, email,  null, null);
     }
 }

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,4 +1,8 @@
-import {ApplicationConfig, importProvidersFrom, provideBrowserGlobalErrorListeners} from '@angular/core';
+import {
+    ApplicationConfig,
+    importProvidersFrom, inject, provideAppInitializer,
+    provideBrowserGlobalErrorListeners
+} from '@angular/core';
 import {provideRouter} from '@angular/router';
 
 import {routes} from './app.routes';
@@ -8,6 +12,7 @@ import {ApiModule, Configuration} from '../../typescript-client';
 import {MessageService} from "primeng/api";
 import {provideHttpClient, withInterceptors} from "@angular/common/http";
 import {authInterceptor} from "./auth/auth-interceptor";
+import {UserDetailsService} from "./services/UserDetailsService/user-details-service";
 
 export const appConfig: ApplicationConfig = {
     providers: [
@@ -26,6 +31,11 @@ export const appConfig: ApplicationConfig = {
                     darkModeSelector: '.my-app-dark'
                 }
             }
+        }),
+        MessageService,
+        provideAppInitializer(() => {
+            const userDetailsService = inject(UserDetailsService);
+            return userDetailsService.loadCurrentUser();
         }),
         MessageService,
         provideHttpClient(withInterceptors([authInterceptor])),

--- a/frontend/src/app/home/feature/home-page/home-page.html
+++ b/frontend/src/app/home/feature/home-page/home-page.html
@@ -5,10 +5,9 @@
 
         <div class="flex flex-col gap-6">
             @for (group of filteredHobbyGroups(); track group.id) {
-                <app-hobby-group-card
-                        [cardTitle]="group.name ?? ''"
-                        [cardDescription]="group.description ?? ''"
-                        [cardTagsIds]="group.tagIds"/>
+                <app-hobby-group-card [hobbyGroupDto]="group"
+                                      (groupUpdated)="onGroupUpdated()"
+                                      (groupDeleted)="onGroupDeleted()"/>
             }
 
             <div #scrollAnchor class="h-20 w-full flex justify-center items-center">

--- a/frontend/src/app/home/feature/home-page/home-page.ts
+++ b/frontend/src/app/home/feature/home-page/home-page.ts
@@ -8,7 +8,6 @@ import {IconField} from "primeng/iconfield";
 import {InputIcon} from "primeng/inputicon";
 import {CreateHobbyGroup} from "../../ui/create-hobby-group/create-hobby-group";
 
-
 @Component({
     selector: 'app-home-page',
     imports: [
@@ -80,9 +79,9 @@ export class HomePage implements OnInit {
             });
     }
 
-    getFilteredHobbyGroups(page: number){
+    getFilteredHobbyGroups(page: number) {
         this.loading.set(true);
-        this.hobbyGroupService.filterAllHobbyGroupsByName(this.searchQuery().trim(), {size:5, page:page})
+        this.hobbyGroupService.filterAllHobbyGroupsByName(this.searchQuery().trim(), {size: 5, page: page})
             .subscribe({
                 next: (response) => {
                     const newItems = response.content ?? [];
@@ -113,6 +112,23 @@ export class HomePage implements OnInit {
         const atBottom = element.scrollHeight - element.scrollTop <= element.clientHeight + threshold;
         if (atBottom && !this.loading() && this.filteredHobbyGroups().length < this.totalRecords()) {
             this.loadMore();
+        }
+    }
+
+    onGroupUpdated() {
+        this.refreshGroups();
+    }
+
+    onGroupDeleted() {
+        this.refreshGroups();
+    }
+
+    refreshGroups() {
+        this.currentPage.set(0);
+        if (this.searchQuery().trim()) {
+            this.getFilteredHobbyGroups(0);
+        } else {
+            this.getHobbyGroups(0);
         }
     }
 }

--- a/frontend/src/app/home/ui/delete-hobby-group/delete-hobby-group.html
+++ b/frontend/src/app/home/ui/delete-hobby-group/delete-hobby-group.html
@@ -1,0 +1,17 @@
+<p-button label="Delete Hobby Group" icon="pi pi-trash" variant="text" (click)="openDialog()"></p-button>
+
+<p-dialog [(visible)]="visible" [modal]="true" [style]="{ width: '25rem' }" appendTo="body" header="Delete Hobby Group">
+
+    <p class="m-0 mb-6">
+        Do you want to delete <strong>{{ hobbyGroupDto().name || 'this hobby group' }}</strong>?<br>
+        Changes will be irreversible.
+    </p>
+
+    <div class="flex gap-4 mt-1 w-full">
+        <p-button label="Cancel" severity="secondary" class="w-full" [outlined]="true" styleClass="w-full"
+                  (click)="visible.set(false)"></p-button>
+        <p-button label="Delete" severity="primary" class="w-full" styleClass="w-full"
+                  (click)="confirmDelete()"></p-button>
+    </div>
+
+</p-dialog>

--- a/frontend/src/app/home/ui/delete-hobby-group/delete-hobby-group.ts
+++ b/frontend/src/app/home/ui/delete-hobby-group/delete-hobby-group.ts
@@ -1,0 +1,44 @@
+import {Component, inject, input, output, signal} from '@angular/core';
+import {Button} from "primeng/button";
+import {Dialog} from "primeng/dialog";
+import {ToastService} from "../../../toast-service/toast-service";
+import {HobbyGroupControllerService} from "@app/api/api/hobbyGroupController.service";
+import {HobbyGroupDto} from "@app/api/model/hobbyGroupDto";
+
+@Component({
+    selector: 'app-delete-hobby-group',
+    imports: [
+        Button,
+        Dialog
+    ],
+    templateUrl: './delete-hobby-group.html',
+})
+export class DeleteHobbyGroup {
+    hobbyGroupService = inject(HobbyGroupControllerService);
+    toastService = inject(ToastService);
+    hobbyGroupDto = input.required<HobbyGroupDto>();
+    visible = signal<boolean>(false);
+
+    groupDeleted = output<string>();
+
+    openDialog() {
+        this.visible.set(true);
+    }
+
+    confirmDelete() {
+        const hobbyGroupId = this.hobbyGroupDto().id;
+        if (hobbyGroupId) {
+            this.hobbyGroupService.deleteHobbyGroup(hobbyGroupId).subscribe({
+                next: () => {
+                    this.visible.set(false);
+                    this.toastService.showSuccess("Hobby Group was successfully deleted.");
+                    this.groupDeleted.emit(hobbyGroupId);
+                },
+                error: () => {
+                    this.toastService.showError("Could not delete hobby group.");
+                }
+
+            });
+        }
+    }
+}

--- a/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.html
+++ b/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.html
@@ -1,8 +1,8 @@
 <p-card>
     <ng-template #title>
-        <h3>{{ cardTitle() }}</h3></ng-template>
+        <h3>{{ hobbyGroupDto().name}}</h3></ng-template>
     <p>
-        {{ cardDescription() }}
+        {{ hobbyGroupDto().description }}
     </p>
     <ng-template #footer>
         <div class="flex flex-row justify-between items-center">
@@ -18,7 +18,18 @@
             </div>
         </div>
         <div class="flex gap-4 mt-2 -mb-4">
-            <p-button label="Join" icon="pi pi-users" variant="text"/>
+
+            @if(!isOwner()){
+                @if(!isMember()){
+                    <p-button label="Join" icon="pi pi-plus-circle" variant="text" (click)="join()"/>
+                } @else {
+                    <p-button label="Leave" icon="pi pi-minus-circle" variant="text" (click)="leave()"/>
+                }
+            }
+            @else{
+                <app-delete-hobby-group [hobbyGroupDto]="hobbyGroupDto()" (groupDeleted)="groupDeleted.emit()">
+                </app-delete-hobby-group>
+                }
         </div>
     </ng-template>
 

--- a/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.ts
+++ b/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.ts
@@ -1,4 +1,4 @@
-import {Component, inject, input} from '@angular/core';
+import {Component, computed, inject, input, output} from '@angular/core';
 import {Card} from "primeng/card";
 import {Avatar} from "primeng/avatar";
 import {Chip} from "primeng/chip";
@@ -6,6 +6,11 @@ import {Button} from "primeng/button";
 import {TagControllerService} from "@app/api/api/tagController.service";
 import {forkJoin, of, switchMap} from "rxjs";
 import {toObservable, toSignal} from "@angular/core/rxjs-interop";
+import {UserDetailsService} from "../../../services/UserDetailsService/user-details-service";
+import {HobbyGroupDto} from "@app/api/model/hobbyGroupDto";
+import {HobbyGroupControllerService} from "@app/api/api/hobbyGroupController.service";
+import {ToastService} from "../../../toast-service/toast-service";
+import {DeleteHobbyGroup} from "../delete-hobby-group/delete-hobby-group";
 
 @Component({
     selector: 'app-hobby-group-card',
@@ -14,24 +19,65 @@ import {toObservable, toSignal} from "@angular/core/rxjs-interop";
         Avatar,
         Chip,
         Button,
+        DeleteHobbyGroup,
     ],
+    standalone: true,
     templateUrl: './hobby-group-card.html'
 })
 export class HobbyGroupCard {
 
-    cardTitle = input.required<string>()
-    cardDescription = input.required<string>()
-    cardTagsIds = input<number[]>()
+    hobbyGroupDto = input.required<HobbyGroupDto>()
+    hobbyGroupService = inject(HobbyGroupControllerService);
     tagService = inject(TagControllerService)
+    userDetailsService = inject(UserDetailsService);
+    groupUpdated = output<void>();
+    toastService = inject(ToastService);
+    groupDeleted = output<void>();
 
-    private tags = toObservable(this.cardTagsIds).pipe(
-        switchMap(ids => {
+    isMember = computed(() =>
+        (this.hobbyGroupDto().memberIds as unknown as string[])
+            ?.includes(this.userDetailsService.getCurrentUser()?.id ?? '')
+    );
+    isOwner = computed(() =>
+        this.hobbyGroupDto().ownerID === this.userDetailsService.getCurrentUser()?.id
+    );
+    private tags = toObservable(this.hobbyGroupDto).pipe(
+        switchMap(group => {
+            const ids = group.tagIds;
             if (!ids || ids.length === 0) return of([]);
             const requests = ids.map(id => this.tagService.getTagById(id));
             return forkJoin(requests);
         })
     );
-
     cardTags = toSignal(this.tags, {initialValue: []});
+
+    join() {
+        this.hobbyGroupService.joinHobbyGroup(this.hobbyGroupDto().id!)
+            .subscribe({
+                next: () => {
+                    this.groupUpdated.emit();
+                    this.toastService.showSuccess("You joined the group.")
+                },
+                error: () => {
+                    this.toastService.showError("Failed to join group.");
+                }
+            });
+    }
+
+    leave() {
+        this.hobbyGroupService.leaveHobbyGroup(this.hobbyGroupDto().id!)
+            .subscribe({
+
+                next: () => {
+                    this.groupUpdated.emit();
+                    this.toastService.showSuccess("You left the group");
+                },
+                error: () => {
+                    this.toastService.showError("Failed to leave group.");
+                }
+            });
+    }
+
+
 }
 

--- a/frontend/src/app/services/UserDetailsService/user-details-service.ts
+++ b/frontend/src/app/services/UserDetailsService/user-details-service.ts
@@ -1,0 +1,26 @@
+import {computed, inject, Injectable, signal} from '@angular/core';
+import {UserControllerService} from "@app/api/api/userController.service";
+import {UserDto} from "@app/api/model/userDto";
+import {firstValueFrom} from "rxjs";
+
+@Injectable({
+    providedIn: 'root',
+})
+export class UserDetailsService {
+    userService = inject(UserControllerService);
+    private currentUser = signal<UserDto | null>(null);
+
+    getCurrentUser = computed(() => this.currentUser());
+
+    async loadCurrentUser() {
+        try {
+            const user = await firstValueFrom(
+                this.userService.getUserInformation()
+            );
+            this.currentUser.set(user);
+        } catch {
+            this.currentUser.set(null); // not logged in yet
+        }
+    }
+
+}


### PR DESCRIPTION
Created the join and leave backend endpoints. Modified the hobby group, so it has a list of members, instead of a set. Added a getUserInformation in the UserController. Implemented the join and leave actions in the frontend. If the current logged in user sees a hobby group owned by him, he won't see the join/leave actions, but a delete button. That will take him to a dialog where he can confirm or cancel the action.

 Modified the UserDTO ( added the user ID and removed the user password). Added a user mapper, that has only the toDto method (I did not think it made a lot of sense to have the toEntity method)

Refs: #73