### PR TITLE
refactor(BE): Adapt seeding script to use services

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/databaseseed/DatabaseSeedService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/databaseseed/DatabaseSeedService.java
@@ -1,20 +1,27 @@
 package cloudflight.integra.backend.databaseseed;
 
 import cloudflight.integra.backend.event.EventRepository;
+import cloudflight.integra.backend.event.EventService;
 import cloudflight.integra.backend.event.model.Event;
 import cloudflight.integra.backend.hobbyGroup.HobbyGroupRepository;
+import cloudflight.integra.backend.hobbyGroup.HobbyGroupService;
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
 import cloudflight.integra.backend.location.LocationRepository;
+import cloudflight.integra.backend.location.LocationService;
 import cloudflight.integra.backend.location.model.Location;
+import cloudflight.integra.backend.security.RegisterRequest;
 import cloudflight.integra.backend.systemFeedback.SystemFeedbackRepository;
+import cloudflight.integra.backend.systemFeedback.SystemFeedbackService;
 import cloudflight.integra.backend.systemFeedback.model.SystemFeedback;
 import cloudflight.integra.backend.tag.TagRepository;
+import cloudflight.integra.backend.tag.TagService;
 import cloudflight.integra.backend.tag.model.Tag;
 import cloudflight.integra.backend.user.Role;
 import cloudflight.integra.backend.user.UserRepository;
+import cloudflight.integra.backend.user.UserService;
 import cloudflight.integra.backend.user.model.User;
 import jakarta.transaction.Transactional;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.github.javafaker.Faker;
@@ -32,14 +39,28 @@ public class DatabaseSeedService {
     private final SystemFeedbackRepository systemFeedbackRepository;
     private final HobbyGroupRepository hobbyGroupRepository;
     private final EventRepository eventRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final UserService userService;
+    private final LocationService locationService;
+    private final TagService tagService;
+    private final SystemFeedbackService systemFeedbackService;
+    private final HobbyGroupService hobbyGroupService;
+    private final EventService eventService;
     private final Faker faker = new Faker(new Random(123));
 
     public DatabaseSeedService(
-        UserRepository userRepository, LocationRepository locationRepository,
-        TagRepository tagRepository, SystemFeedbackRepository systemFeedbackRepository,
-        HobbyGroupRepository hobbyGroupRepository, EventRepository eventRepository,
-        PasswordEncoder passwordEncoder
+        UserRepository userRepository,
+        LocationRepository locationRepository,
+        TagRepository tagRepository,
+        SystemFeedbackRepository systemFeedbackRepository,
+        HobbyGroupRepository hobbyGroupRepository,
+        EventRepository eventRepository,
+
+        UserService userService,
+        LocationService locationService,
+        TagService tagService,
+        SystemFeedbackService systemFeedbackService,
+        HobbyGroupService hobbyGroupService,
+        EventService eventService
     ) {
         this.userRepository = userRepository;
         this.locationRepository = locationRepository;
@@ -47,7 +68,13 @@ public class DatabaseSeedService {
         this.systemFeedbackRepository = systemFeedbackRepository;
         this.hobbyGroupRepository = hobbyGroupRepository;
         this.eventRepository = eventRepository;
-        this.passwordEncoder = passwordEncoder;
+
+        this.eventService = eventService;
+        this.userService = userService;
+        this.locationService = locationService;
+        this.tagService = tagService;
+        this.systemFeedbackService = systemFeedbackService;
+        this.hobbyGroupService = hobbyGroupService;
     }
 
     public void seedDatabase() {
@@ -69,34 +96,35 @@ public class DatabaseSeedService {
     }
 
     private void seedUsersTable() {
-        if (userRepository.count() > 0) {
+        if (userService.getByUsername("Leo") != null) {
             return;
         }
-        String password = passwordEncoder.encode("Password12@");
 
-        User admin = new User();
-        admin.setUsername("Leo");
-        admin.setEmail("leo@commonground.com");
-        admin.setPassword(password);
+        RegisterRequest adminReq = new RegisterRequest(
+            "Leo",
+            "leo@commonground.com",
+            "Password12@"
+        );
+        User admin = userService.register(adminReq);
         admin.setRole(Role.ADMIN);
         admin.setJoinedDate(LocalDateTime.of(2026, 4, 1, 12, 0));
-        userRepository.save(admin);
 
         int i = 3;
         while (i > 0) {
-            User user = new User();
-            user.setUsername(faker.funnyName().name());
-            user.setEmail(faker.internet().safeEmailAddress());
-            user.setPassword(password);
-            user.setRole(Role.USER);
-            user.setJoinedDate(LocalDateTime.of(2026, 4, faker.number().numberBetween(1, 30), 12, 0));
-            userRepository.save(user);
+            RegisterRequest userReq = new RegisterRequest(
+                faker.funnyName().name(),
+                faker.internet().safeEmailAddress(),
+                "Password12@"
+            );
+            User user = userService.register(userReq);
+            user.setJoinedDate(LocalDateTime.of(
+                2026, 4, faker.number().numberBetween(1, 30), 12, 0));
             i--;
         }
     }
 
     private void seedLocationsTable() {
-        if (locationRepository.count() > 0) {
+        if (!locationService.getAll(Pageable.unpaged()).isEmpty()) {
             return;
         }
         int i = 10;
@@ -105,14 +133,14 @@ public class DatabaseSeedService {
             location.setName(truncate(faker.lordOfTheRings().location()));
             location.setLatitude(faker.number().randomDouble(4, 0, 90));
             location.setLongitude(faker.number().randomDouble(4, 0, 90));
-            locationRepository.save(location);
+            locationService.create(location);
             i--;
         }
 
     }
 
     private void seedSystemFeedbackTable() {
-        if (systemFeedbackRepository.count() > 0) {
+        if (!systemFeedbackService.getAll().isEmpty()) {
             return;
         }
         int i = 10;
@@ -120,8 +148,9 @@ public class DatabaseSeedService {
             SystemFeedback systemFeedback = new SystemFeedback();
             systemFeedback.setEmail(faker.internet().emailAddress());
             systemFeedback.setMessage(truncate(faker.chuckNorris().fact()));
-            systemFeedback.setCreatedAt(LocalDateTime.of(2026, 4, faker.number().numberBetween(1, 30), 12, 0));
-            systemFeedbackRepository.save(systemFeedback);
+            systemFeedback.setCreatedAt(LocalDateTime.of(
+                2026, 4, faker.number().numberBetween(1, 30), 12, 0));
+            systemFeedbackService.create(systemFeedback);
             i--;
         }
 
@@ -129,7 +158,7 @@ public class DatabaseSeedService {
     }
 
     private void seedTagsTable() {
-        if (tagRepository.count() > 0) {
+        if (!tagService.getAll(Pageable.unpaged()).isEmpty()) {
             return;
         }
         String[] labels = {
@@ -144,46 +173,47 @@ public class DatabaseSeedService {
             Tag tag = new Tag();
             tag.setLabel(truncate(label));
             tag.setNormalizedLabel(truncate(label).toLowerCase());
-            tagRepository.save(tag);
+            tagService.create(tag);
         }
 
     }
 
     private void seedHobbyGroupsTable() {
-        if (hobbyGroupRepository.count() > 0) {
+        if (!hobbyGroupService.getAll(Pageable.unpaged()).isEmpty()) {
             return;
         }
         int i = 10;
-        User user = userRepository.findByEmail("leo@commonground.com");
+        User user = userService.findByEmail("leo@commonground.com");
         while (i > 0) {
             HobbyGroup hobbyGroup = new HobbyGroup();
             hobbyGroup.setName(truncate(faker.space().nebula()));
             hobbyGroup.setDescription(truncate(faker.yoda().quote()));
             hobbyGroup.setRadiusKm(faker.number().numberBetween(0, 10));
             hobbyGroup.setOwner(user);
-            hobbyGroupRepository.save(hobbyGroup);
+            hobbyGroupService.create(hobbyGroup);
             i--;
         }
 
     }
 
     private void seedEventsTable() {
-        if (eventRepository.count() > 0) {
+        if (!eventService.getAll(Pageable.unpaged()).isEmpty()) {
             return;
         }
-        List<Location> locations = locationRepository.findAll();
-        List<HobbyGroup> hobbyGroups = hobbyGroupRepository.findAll();
+        List<Location> locations = locationService.getAllList();
+        List<HobbyGroup> hobbyGroups = hobbyGroupService.getAllList();
         if (locations.isEmpty() || hobbyGroups.isEmpty()) return;
         int i = 10;
         while (i > 0) {
             Event event = new Event();
             event.setTitle(truncate(faker.cat().name()));
-            LocalDateTime startTime = LocalDateTime.of(2026, 4, faker.number().numberBetween(1, 30), 12, 0);
+            LocalDateTime startTime = LocalDateTime.of(
+                2026, 4, faker.number().numberBetween(1, 30), 12, 0);
             event.setStartTime(startTime);
             event.setEndTime(startTime.plusHours(2));
             event.setLocation(locations.get(faker.number().numberBetween(0, locations.size())));
             event.setHobbyGroup(hobbyGroups.get(faker.number().numberBetween(0, hobbyGroups.size())));
-            eventRepository.save(event);
+            eventService.create(event);
             i--;
         }
     }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
@@ -5,6 +5,7 @@ import cloudflight.integra.backend.emailSystem.UserJoinedGroupEvent;
 import cloudflight.integra.backend.exceptions.AlreadyMemberOfThisHobbyGroupException;
 import cloudflight.integra.backend.exceptions.NotMemberOfHobbyGroupException;
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
+import cloudflight.integra.backend.location.model.Location;
 import cloudflight.integra.backend.user.model.User;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
@@ -33,6 +35,9 @@ public class HobbyGroupService {
     public Page<HobbyGroup> getAll(Pageable pageable) {
         return repository.findAll(pageable);
     }
+
+    @Transactional(readOnly = true)
+    public List<HobbyGroup> getAllList(){ return repository.findAll(); }
 
     @Transactional(readOnly = true)
     public HobbyGroup getById(UUID id) {

--- a/backend/src/main/java/cloudflight/integra/backend/location/LocationService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/location/LocationService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -21,6 +22,9 @@ public class LocationService {
     public Page<Location> getAll(Pageable pageable) {
         return repository.findAll(pageable);
     }
+
+    @Transactional(readOnly = true)
+    public List<Location> getAllList(){ return repository.findAll(); }
 
     @Transactional(readOnly = true)
     public Location getById(UUID id) {

--- a/backend/src/main/java/cloudflight/integra/backend/user/UserService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/UserService.java
@@ -51,4 +51,6 @@ public class UserService implements UserDetailsService {
     public User getByUsername(String username) {
         return userRepository.findByUsername(username);
     }
+
+    public User findByEmail(String email){ return userRepository.findByEmail(email); }
 }


### PR DESCRIPTION
- when creating the seeding tables, the seeding script interacts with the services, not the repositories
- added some new getAllList methods to Location and HobbyGroup services so i can get them as a list when seeding the event table
- added a findByEmail method in UserService so we dont use the repositoy method to find emails
- delete continues to use the repositories deleteAll methods unfortunatelly but thats okay, creating involves only service methods
- deleted password encoder because it was not needed

Refs: #125