### PR TITLE
refactor(FE): Proper Login Flow

### DIFF
--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -2,18 +2,23 @@
         position="top-right"
         [breakpoints]="{ '920px': { width: '100%', right: '0', left: '0' } }">
 </p-toast>
-<div class="lg:hidden flex items-center bg-primary text-white">
-    <app-sidebar/>
-</div>
-
-<div class="min-h-screen flex flex-col lg:flex-row overflow-hidden">
-    <header class="hidden lg:block w-80 h-screen sticky top-0">
-        <app-sidebar/>
-    </header>
-
-    <main class="flex-1">
-        <div class="h-screen overflow-y-auto p-4 lg:p-8">
-            <router-outlet/>
-        </div>
+@if (hideSidebar) {
+    <main class="min-h-screen flex items-center justify-center bg-surface-50">
+        <router-outlet/>
     </main>
-</div>
+} @else {
+    <div class="lg:hidden flex items-center bg-primary text-white">
+        <app-sidebar/>
+    </div>
+    <div class="min-h-screen flex flex-col lg:flex-row overflow-hidden">
+        <header class="hidden lg:block w-80 h-screen sticky top-0">
+            <app-sidebar/>
+        </header>
+
+        <main class="flex-1">
+            <div class="h-screen overflow-y-auto p-4 lg:p-8">
+                <router-outlet/>
+            </div>
+        </main>
+    </div>
+}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -11,8 +11,21 @@ import {authGuard} from "./auth/auth-guard";
 import {ProfilePage} from "./profile/feature/profile-page/profile-page";
 
 export const routes: Routes = [
+
+    { path: '', redirectTo: '/login', pathMatch: 'full' },
+
     {
-        path: '',
+        path: 'login',
+        component: LoginPage,
+    },
+
+    {
+        path: 'registration',
+        component: Registration,
+    },
+
+    {
+        path: 'home',
         title: "Home",
         component: HomePage,
         data: {icon: 'pi-home'}
@@ -30,20 +43,6 @@ export const routes: Routes = [
         title:"Feedback",
         component:FeedbackPage,
         data: {icon: 'pi-comment'}
-    },
-
-    {
-        path: 'login',
-        title: "Login",
-        component: LoginPage,
-        data: {icon: 'pi-sign-in'}
-    },
-
-    {
-        path: 'registration',
-        title: 'User Registration',
-        component: Registration,
-        data: { icon: 'pi-user-plus' }
     },
 
     {

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,7 +1,7 @@
-import {Component, signal} from '@angular/core';
-import {RouterOutlet} from '@angular/router';
-import {Sidebar} from "./sidebar/feature/sidebar/sidebar";
-import {Toast} from "primeng/toast";
+import { Component, inject } from '@angular/core';
+import { Router, RouterOutlet } from '@angular/router';
+import { Sidebar } from "./sidebar/feature/sidebar/sidebar";
+import { Toast } from "primeng/toast";
 
 @Component({
     selector: 'app-root',
@@ -10,5 +10,9 @@ import {Toast} from "primeng/toast";
     styleUrl: './app.css',
 })
 export class App {
-    protected readonly title = signal('frontend');
+    private router = inject(Router);
+
+    get hideSidebar(): boolean {
+        return this.router.url.includes('/login') || this.router.url.includes('/registration');
+    }
 }

--- a/frontend/src/app/auth/auth-guard.ts
+++ b/frontend/src/app/auth/auth-guard.ts
@@ -9,6 +9,6 @@ export const authGuard: CanActivateFn = (route, state) => {
     if (userDetailService.isAdmin()) {
         return true;
     }
-    router.navigate(['/']);
+    router.navigate(['/home']);
     return false;
 };

--- a/frontend/src/app/login/feature/login-page/login-page.ts
+++ b/frontend/src/app/login/feature/login-page/login-page.ts
@@ -28,7 +28,7 @@ export class LoginPage {
                 this.toastService.showSuccess("Logged in successfully!");
 
                 setTimeout(() => {
-                    this.router.navigate(['/']).then(() => {
+                    this.router.navigate(['/home']).then(() => {
                     });
                 }, 1500);
             },

--- a/frontend/src/app/login/ui/login-form/login-form.html
+++ b/frontend/src/app/login/ui/login-form/login-form.html
@@ -1,71 +1,65 @@
-<div class="px-6 py-20">
-    <div class="bg-surface-50 p-8 md:p-12 shadow-sm rounded-2xl w-full max-w-sm mx-auto flex flex-col gap-8">
-        <div class="flex flex-col items-center gap-4">
-            <div class="flex items-center gap-4">
-            </div>
+<div class="px-6 py-20 flex justify-center items-center min-h-screen w-full">
+    <div class="bg-surface-0 border border-[#E0E0E0] rounded-3xl
+    p-14 w-full max-w-137.5 flex flex-col h-fit mx-auto gap-8">
+        <div class="flex flex-col items-center gap-4 w-full">
             <div class="flex flex-col items-center gap-2 w-full">
-                <div class="text-surface-900 dark:text-surface-0 text-2xl font-semibold leading-tight
-                text-center w-full">
+                <div class="text-surface-900 dark:text-surface-0 text-3xl
+                font-semibold leading-tight text-center w-full">
                     Log In
                 </div>
-                <div class="text-center w-full">
+                <div class="text-center w-full mt-1">
                     <span class="text-surface-700 dark:text-surface-200 leading-normal">Don't have an account?</span>
-                    <a class="text-primary font-medium ml-1 cursor-pointer hover:text-primary-emphasis"
+                    <a class="text-primary font-medium ml-1 cursor-pointer hover:underline transition-colors"
                        routerLink="/registration">Register!</a>
                 </div>
             </div>
         </div>
-        <div class="card flex justify-center">
-            <form #loginForm="ngForm" (ngSubmit)="onSubmit(loginForm)" class="flex flex-col gap-4 sm:w-56">
-                <div class="flex flex-col gap-6 w-full">
-                    <div class="flex flex-col gap-2 w-full">
-                        <label for="username" class="text-surface-900 dark:text-surface-0 font-medium leading-normal">
-                            Username
-                        </label>
-                        <input
-                                pInputText
-                                [(ngModel)]="request.username"
-                                name="username"
-                                id="username"
-                                placeholder="Username"
-                                class="w-full px-3 py-2 shadow-sm rounded-lg"
-                                #username="ngModel"
-                                [invalid]="username.invalid && (username.touched || loginForm.submitted)" required
-                        />
-                        @if (username.invalid && (username.touched || loginForm.submitted)) {
-                            <p-message severity="error" size="small" variant="simple">Username is required</p-message>
-                        }
-                    </div>
-                    <div class="flex flex-col gap-2 w-full">
-                        <label for="password" class="text-surface-900 dark:text-surface-0 font-medium leading-normal">
-                            Password
-                        </label>
-                        <p-password
-                                [(ngModel)]="request.password"
-                                variant="filled"
-                                name="password"
-                                inputId="password"
-                                placeholder="Password"
-                                class="w-full"
-                                inputStyleClass="w-full px-3 py-2 shadow-sm rounded-lg"
-                                [feedback]="false"
-                                [toggleMask]="true"
-                                #password="ngModel"
-                                [invalid]="password.invalid && (password.touched || loginForm.submitted)" required
-                        ></p-password>
-                        @if (password.invalid && (password.touched || loginForm.submitted)) {
-                            <p-message severity="error" size="small" variant="simple">Password is required</p-message>
-                        }
-                    </div>
-                    <div class="flex flex-col sm:flex-row items-start
-                    sm:items-center justify-between w-full gap-3 sm:gap-0">
-                    </div>
-                    <button pButton class="w-full py-2 rounded-lg flex justify-center items-center gap-2">
-                        <i pButtonIcon class="pi pi-user text-base! leading-normal!"></i>
-                        <span pButtonLabel>Log in</span>
-                    </button>
+        <form #loginForm="ngForm" (ngSubmit)="onSubmit(loginForm)" class="flex flex-col gap-6 w-full mt-2">
+            <div class="flex flex-col gap-5 w-full">
+                <div class="flex flex-col gap-2 w-full">
+                    <label for="username" class="text-surface-900 dark:text-surface-0 font-medium leading-normal">
+                        Username
+                    </label>
+                    <input
+                            pInputText
+                            [(ngModel)]="request.username"
+                            name="username"
+                            id="username"
+                            placeholder="Username"
+                            class="w-full px-3 py-2 shadow-sm rounded-lg"
+                            #username="ngModel"
+                            [invalid]="username.invalid && (username.touched || loginForm.submitted)" required
+                    />
+                    @if (username.invalid && (username.touched || loginForm.submitted)) {
+                        <p-message severity="error" size="small" variant="simple">Username is required</p-message>
+                    }
                 </div>
-            </form>
-        </div>
+                <div class="flex flex-col gap-2 w-full">
+                    <label for="password" class="text-surface-900 dark:text-surface-0 font-medium leading-normal">
+                        Password
+                    </label>
+                    <p-password
+                            [(ngModel)]="request.password"
+                            variant="filled"
+                            name="password"
+                            inputId="password"
+                            placeholder="Password"
+                            class="w-full"
+                            inputStyleClass="w-full px-3 py-2 shadow-sm rounded-lg"
+                            [feedback]="false"
+                            [toggleMask]="true"
+                            #password="ngModel"
+                            [invalid]="password.invalid && (password.touched || loginForm.submitted)" required
+                    ></p-password>
+                    @if (password.invalid && (password.touched || loginForm.submitted)) {
+                        <p-message severity="error" size="small" variant="simple">Password is required</p-message>
+                    }
+                </div>
+                <button pButton class="w-full mt-6 py-2 rounded-lg flex justify-center items-center gap-2">
+                    <i pButtonIcon class="pi pi-user text-base! leading-normal!"></i>
+                    <span pButtonLabel>Log in</span>
+                </button>
+            </div>
+        </form>
     </div>
 </div>

--- a/frontend/src/app/registration/registration.html
+++ b/frontend/src/app/registration/registration.html
@@ -1,120 +1,96 @@
-<div class="px-6 py-20">
-    <div class="bg-surface-50 p-8 md:p-12 shadow-sm rounded-2xl w-full max-w-sm mx-auto flex flex-col gap-8">
-        <div class="flex flex-col items-center gap-4">
-            <div class="flex items-center gap-4">
+<div class="px-4 py-12 flex justify-center items-center min-h-screen w-full">
+    <div class="bg-surface-0 border border-[#E0E0E0]
+    rounded-3xl p-14 w-full max-w-137.5 flex flex-col h-fit mx-auto gap-8">
+        <div class="flex flex-col items-center gap-2 w-full">
+            <div class="text-surface-900 dark:text-surface-0 text-3xl font-semibold leading-tight text-center w-full">
+                Register Here
             </div>
-            <div class="flex flex-col items-center gap-2 w-full">
-                <div class="text-surface-900 dark:text-surface-0 text-2xl font-semibold leading-tight
-                text-center w-full">
-                    Register Here
-                </div>
-                <div class="text-center w-full">
-                    <span class="text-surface-700 dark:text-surface-200 leading-normal">Already have an account?</span>
-                    <a class="text-primary font-medium ml-1 cursor-pointer hover:text-primary-emphasis"
-                       routerLink="/login">Log in!</a>
-                </div>
+            <div class="text-center w-full mt-1">
+                <span class="text-surface-700 dark:text-surface-200 leading-normal">Already have an account?</span>
+                <a class="text-primary font-medium ml-1 cursor-pointer hover:underline transition-colors"
+                   routerLink="/login">Log in!</a>
             </div>
         </div>
-        <div class="card flex justify-center">
-            <form [formGroup]="registerForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-4 sm:w-56">
-                <div class="flex flex-col gap-6 w-full">
-                    <div class="flex flex-col gap-2 w-full">
-                        <label class="text-surface-900 dark:text-surface-0 font-medium leading-normal">Username</label>
-                        <input pInputText formControlName="username" placeholder="Username"
-                               class="w-full px-3 py-2 shadow-sm rounded-lg"/>
-                        @if (registerForm.get('username')?.invalid &&
-                        registerForm.get('username')?.touched) {
-
-                            @if (registerForm.get('username')?.hasError('required')) {
-                                <p-message severity="error" size="small" variant="simple">
-                                    Username is required.
-                                </p-message>
-                            }
-
-                            @if (registerForm.get('username')?.hasError('usernameTaken')) {
-                                <p-message severity="error" size="small" variant="simple">
-                                    This username is already taken! Please choose another.
-                                </p-message>
-                            }
+        <form [formGroup]="registerForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-4 w-full mt-4">
+            <div class="flex flex-col gap-4 w-full">
+                <div class="flex flex-col gap-1 w-full">
+                    <label class="text-surface-900 dark:text-surface-0 font-medium leading-normal">Username</label>
+                    <input pInputText formControlName="username" placeholder="Username"
+                           class="w-full px-3 py-3 shadow-sm rounded-lg"/>
+                    @if (registerForm.get('username')?.invalid && registerForm.get('username')?.touched) {
+                        @if (registerForm.get('username')?.hasError('required')) {
+                            <p-message severity="error" size="small" variant="simple">Username is required.</p-message>
                         }
-                    </div>
-                    <div class="flex flex-col gap-2 w-full">
-                        <label class="text-surface-900 dark:text-surface-0 font-medium leading-normal">Email
-                            Address</label>
-                        <input pInputText formControlName="email" placeholder="Email address"
-                               class="w-full px-3 py-2 shadow-sm rounded-lg"/>
-                        @if (registerForm.get('email')?.invalid && (registerForm.get('email')?.touched)) {
-                            <p-message severity="error" size="small" variant="simple">
-                                Email is required.
+                        @if (registerForm.get('username')?.hasError('usernameTaken')) {
+                            <p-message severity="error" size="small" variant="simple">This username is already taken!
+                                Please choose another.
                             </p-message>
                         }
-                    </div>
-                    <div class="flex flex-col gap-2 w-full">
-                        <label class="text-surface-900 dark:text-surface-0 font-medium leading-normal">Password</label>
-                        <p-password
-                                formControlName="password"
-                                variant="filled"
-                                placeholder="Password"
-                                class="w-full"
-                                inputStyleClass="w-full px-3 py-2 shadow-sm rounded-lg"
-                                [feedback]="false"
-                                [toggleMask]="true">
-                        </p-password>
-                        @if (registerForm.get('password')?.invalid && (registerForm.get('password')?.dirty
-                                || registerForm.get('password')?.touched)) {
-
-                            @if (registerForm.get('password')?.hasError('required')) {
-                                <p-message severity="error" size="small" variant="simple">
-                                    Password is required.
-                                </p-message>
-                            }
-
-                            @if (registerForm.get('password')?.hasError('minlength')
-                            || registerForm.get('password')?.hasError('pattern')) {
-                                <p-message severity="error" size="small" variant="simple">
-                                    Password must be at least 8 characters long, include an uppercase letter, a number,
-                                    and a special symbol.
-                                </p-message>
-                            }
-                        }
-
-                    </div>
-                    <div class="flex flex-col gap-2 w-full">
-                        <label class="text-surface-900 dark:text-surface-0 font-medium leading-normal">Confirm
-                            Password</label>
-                        <p-password
-                                formControlName="confirmPassword"
-                                variant="filled"
-                                placeholder="Confirm Password"
-                                class="w-full"
-                                inputStyleClass="w-full px-3 py-2 shadow-sm rounded-lg"
-                                [feedback]="false"
-                                [toggleMask]="true">
-                        </p-password>
-                        @if (registerForm.get('confirmPassword')?.dirty ||
-                        registerForm.get('confirmPassword')?.touched) {
-
-                            @if (registerForm.get('confirmPassword')?.hasError('required')) {
-                                <p-message severity="error" size="small" variant="simple">
-                                    Please enter your password again for confirmation.
-                                </p-message>
-
-                            } @else if (registerForm.hasError('passwordMismatch')) {
-                                <p-message severity="error" size="small" variant="simple">
-                                    The Passwords do not match.
-                                </p-message>
-                            }
-                        }
-                    </div>
-                    <div class="flex flex-col sm:flex-row items-start
-                    sm:items-center justify-between w-full gap-3 sm:gap-0">
-                    </div>
-                    <button pButton class="w-full py-2 rounded-lg flex justify-center items-center gap-2">
-                        <i pButtonIcon class="pi pi-user text-base! leading-normal!"></i>
-                        <span pButtonLabel>Register me</span>
-                    </button>
+                    }
                 </div>
-            </form>
-        </div>
+                <div class="flex flex-col gap-1 w-full">
+                    <label class="text-surface-900 dark:text-surface-0 font-medium leading-normal">Email Address</label>
+                    <input pInputText formControlName="email" placeholder="Email address"
+                           class="w-full px-3 py-3 shadow-sm rounded-lg"/>
+                    @if (registerForm.get('email')?.invalid && (registerForm.get('email')?.touched)) {
+                        <p-message severity="error" size="small" variant="simple">Email is required.</p-message>
+                    }
+                </div>
+                <div class="flex flex-col gap-1 w-full">
+                    <label class="text-surface-900 dark:text-surface-0 font-medium leading-normal">Password</label>
+                    <p-password
+                            formControlName="password"
+                            variant="filled"
+                            placeholder="Password"
+                            class="w-full"
+                            inputStyleClass="w-full px-3 py-3 shadow-sm rounded-lg"
+                            [feedback]="false"
+                            [toggleMask]="true">
+                    </p-password>
+                    @if (registerForm.get('password')?.invalid && (registerForm.get('password')?.dirty
+                            || registerForm.get('password')?.touched)) {
+                        @if (registerForm.get('password')?.hasError('required')) {
+                            <p-message severity="error" size="small" variant="simple">Password is required.</p-message>
+                        }
+                        @if (registerForm.get('password')?.hasError('minlength')
+                        || registerForm.get('password')?.hasError('pattern')) {
+                            <p-message severity="error" size="small" variant="simple">Password must be at least 8
+                                characters, include an uppercase letter, a number, and a special symbol.
+                            </p-message>
+                        }
+                    }
+                </div>
+                <div class="flex flex-col gap-1 w-full">
+                    <label class="text-surface-900 dark:text-surface-0 font-medium leading-normal">Confirm
+                        Password</label>
+                    <p-password
+                            formControlName="confirmPassword"
+                            variant="filled"
+                            placeholder="Confirm Password"
+                            class="w-full"
+                            inputStyleClass="w-full px-3 py-3 shadow-sm rounded-lg"
+                            [feedback]="false"
+                            [toggleMask]="true">
+                    </p-password>
+                    @if (registerForm.get('confirmPassword')?.dirty
+                    || registerForm.get('confirmPassword')?.touched) {
+                        @if (registerForm.get('confirmPassword')?.hasError('required')) {
+                            <p-message severity="error" size="small" variant="simple">Please enter your password again
+                                to confirm.
+                            </p-message>
+                        } @else if (registerForm.hasError('passwordMismatch')) {
+                            <p-message severity="error" size="small" variant="simple">The Passwords do not match.
+                            </p-message>
+                        }
+                    }
+                </div>
+            </div>
+            <div class="w-full mt-4">
+                <button pButton class="w-full py-3 rounded-lg flex justify-center items-center gap-2">
+                    <i pButtonIcon class="pi pi-user-plus text-base! leading-normal!"></i>
+                    <span pButtonLabel>Register me</span>
+                </button>
+            </div>
+        </form>
     </div>
 </div>


### PR DESCRIPTION
- the default route is now the login page so if you open the app for the first time you have to log in to access it or register an account
- to make the login and register be "independent" i hid the sidebar on those pages and it shows only on home and the other views as it should
- changed some of the styling so it looks a little bit better when it comes to the login and register forms, i did my best, i could not make them wider :(
- also made sure than when a non admin user tries to access admin pages, he's redirected to the homepage (before there was only the default route and now login is the default route) Refs: #118