### PR TITLE
security(BE): Enforce auth

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/cloudflight/integra/backend/security/SecurityConfig.java
@@ -34,8 +34,11 @@ public class SecurityConfig {
                 (req, resp, ex)
                     -> resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, ex.getMessage())));
 
-        http.authorizeHttpRequests((authorize)
-            -> authorize.anyRequest().permitAll());
+        http.authorizeHttpRequests((authorize) -> authorize
+            .requestMatchers("/api/login", "/api/register").permitAll()
+            .requestMatchers("/api/**").authenticated()
+            .anyRequest().permitAll()
+        );
 
         http.addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
- login and register are permitted for all unauthenticated users
- any other api call requires the user to have an account
- consuming the frontend serverd by the backend still works (i assume)

Refs: #137