### PR TITLE
feat(Matrix): Matrix account provisioning

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixAuthRestClient.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixAuthRestClient.java
@@ -1,0 +1,84 @@
+package cloudflight.integra.backend.matrix.api;
+
+import cloudflight.integra.backend.matrix.api.model.MatrixNonceResponse;
+import cloudflight.integra.backend.matrix.api.model.MatrixRegisterRequest;
+import cloudflight.integra.backend.matrix.api.model.MatrixRegisterResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+@Service
+public class MatrixAuthRestClient {
+    private final RestClient matrixRestClient;
+    private static final String HMAC_ALGORITHM = "HmacSHA1";
+    private final String sharedSecret;
+
+    public MatrixAuthRestClient(
+        RestClient matrixRestClient,
+        @Value("${matrix.registration-shared-secret}") String sharedSecret
+    ) {
+        this.matrixRestClient = matrixRestClient;
+        this.sharedSecret = sharedSecret;
+    }
+
+    public MatrixRegisterResponse register(String username, String password) {
+        MatrixNonceResponse nonceResponse = this.matrixRestClient.get()
+            .uri("/_synapse/admin/v1/register")
+            .retrieve()
+            .body(MatrixNonceResponse.class);
+        String nonce = nonceResponse.nonce();
+
+        String mac = this.getRegisterHmac(nonce, username, password, "notadmin");
+
+        MatrixRegisterRequest request = new MatrixRegisterRequest(
+            nonce,
+            username,
+            password,
+            false,
+            mac
+        );
+
+        return this.matrixRestClient.post()
+            .uri("/_synapse/admin/v1/register")
+            .body(request)
+            .retrieve()
+            .body(MatrixRegisterResponse.class);
+    }
+
+    private String getRegisterHmac(
+        String nonce,
+        String username,
+        String password,
+        String admin
+    ) throws IllegalStateException {
+        try {
+            SecretKeySpec secretKeySpec = new SecretKeySpec(this.sharedSecret.getBytes(StandardCharsets.UTF_8),
+                HMAC_ALGORITHM);
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(secretKeySpec);
+
+            mac.update(nonce.getBytes(StandardCharsets.UTF_8));
+            mac.update(HexFormat.of().parseHex("00"));
+            mac.update(username.getBytes(StandardCharsets.UTF_8));
+            mac.update(HexFormat.of().parseHex("00"));
+            mac.update(password.getBytes(StandardCharsets.UTF_8));
+            mac.update(HexFormat.of().parseHex("00"));
+            byte[] result = mac.doFinal(admin.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hexString = new StringBuilder();
+
+            for (byte b : result) {
+                hexString.append(String.format("%02x", b));
+            }
+
+            return hexString.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to compute HMAC for Matrix registration", e);
+        }
+    }
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixRestClientConfig.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixRestClientConfig.java
@@ -1,0 +1,21 @@
+package cloudflight.integra.backend.matrix.api;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import java.awt.*;
+
+@Configuration
+public class MatrixRestClientConfig {
+
+    @Bean
+    RestClient MatrixRestClient(RestClient.Builder builder, @Value("${matrix.base-url}")  String serverUrl) {
+        return builder
+            .baseUrl(serverUrl)
+            .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/MatrixNonceResponse.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/MatrixNonceResponse.java
@@ -1,0 +1,4 @@
+package cloudflight.integra.backend.matrix.api.model;
+
+public record MatrixNonceResponse(String nonce) {
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/MatrixRegisterRequest.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/MatrixRegisterRequest.java
@@ -1,0 +1,4 @@
+package cloudflight.integra.backend.matrix.api.model;
+
+public record MatrixRegisterRequest(String nonce, String username, String password, boolean admin, String mac) {
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/MatrixRegisterResponse.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/MatrixRegisterResponse.java
@@ -1,0 +1,4 @@
+package cloudflight.integra.backend.matrix.api.model;
+
+public record MatrixRegisterResponse(String access_token, String device_id, String user_id, String home_server) {
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/provisioning/MatrixProvisioningResponse.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/provisioning/MatrixProvisioningResponse.java
@@ -1,0 +1,11 @@
+package cloudflight.integra.backend.matrix.provisioning;
+
+public record MatrixProvisioningResponse(boolean provisioned, String message) {
+    public static MatrixProvisioningResponse ok() {
+        return new MatrixProvisioningResponse(true, null);
+    }
+
+    public static MatrixProvisioningResponse warn(String message) {
+        return new MatrixProvisioningResponse(false, message);
+    }
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/provisioning/MatrixProvisioningService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/provisioning/MatrixProvisioningService.java
@@ -1,0 +1,88 @@
+package cloudflight.integra.backend.matrix.provisioning;
+
+import cloudflight.integra.backend.matrix.api.MatrixAuthRestClient;
+import cloudflight.integra.backend.matrix.api.model.MatrixRegisterResponse;
+import cloudflight.integra.backend.user.UserService;
+import cloudflight.integra.backend.user.model.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.security.SecureRandom;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class MatrixProvisioningService {
+    private final MatrixAuthRestClient matrixRestClient;
+    private final UserService userService;
+    private final String serverName;
+    private final SecureRandom passwordRandom = new SecureRandom();
+    private final ConcurrentHashMap<String, String> temporaryPassword = new ConcurrentHashMap<>();
+
+    public MatrixProvisioningService(
+        MatrixAuthRestClient matrixRestClient,
+        UserService userService,
+        @Value("${matrix.server-name}") String serverName
+    ) {
+        this.matrixRestClient = matrixRestClient;
+        this.userService = userService;
+        this.serverName = serverName;
+    }
+
+    public String getMatrixUserId(User user) {
+        if (user.getMatrixAccessToken() == null) return null;
+
+        return "@" + user.getUsername().toLowerCase() + ":" + this.serverName;
+    }
+
+    public void setTemporaryPassword(User user, String password) {
+        if (user.getMatrixAccessToken() == null) return;
+
+        this.temporaryPassword.put(user.getUsername(), password);
+    }
+
+    public String getTemporaryPassword(User user) {
+        return this.temporaryPassword.get(user.getUsername());
+    }
+
+    public MatrixProvisioningResponse provisionAccount(User user) {
+        String temporaryPassword = this.getTemporaryMatrixPassword();
+
+        try {
+            MatrixRegisterResponse response = matrixRestClient.register(user.getUsername(), temporaryPassword);
+
+            userService.setMatrixAccount(user.getUsername(), response.access_token());
+            this.setTemporaryPassword(user, temporaryPassword);
+
+            return MatrixProvisioningResponse.ok();
+        } catch (IllegalStateException e) {
+            return MatrixProvisioningResponse.warn("Matrix provisioning is not configured correctly");
+
+        } catch (ResourceAccessException e) {
+            return MatrixProvisioningResponse.warn("Matrix homeserver is unreachable");
+
+        } catch (RestClientResponseException e) {
+            HttpStatusCode errorCode = e.getStatusCode();
+            if (errorCode.value() == 409) {
+                return MatrixProvisioningResponse.warn("Matrix account already exists for this username");
+            }
+
+            return MatrixProvisioningResponse.warn("Matrix homeserver rejected request");
+        }
+    }
+
+    public String getTemporaryMatrixPassword() {
+        int passwordLength = 10;
+        String characters = "abcdefghijkmnpqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ23456789!@#$%^&*_+-=";
+        StringBuilder password = new StringBuilder();
+
+        for (int i = 0; i < passwordLength; i++) {
+            int index = this.passwordRandom.nextInt(characters.length());
+            password.append(characters.charAt(index));
+        }
+
+        return password.toString();
+    }
+}

--- a/backend/src/main/java/cloudflight/integra/backend/security/AuthController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/security/AuthController.java
@@ -1,11 +1,14 @@
 package cloudflight.integra.backend.security;
 
+import cloudflight.integra.backend.matrix.provisioning.MatrixProvisioningResponse;
 import cloudflight.integra.backend.user.CustomUserDetails;
+import cloudflight.integra.backend.matrix.provisioning.MatrixProvisioningService;
 import cloudflight.integra.backend.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -20,23 +23,27 @@ import java.time.Duration;
 
 
 @RestController
+@Profile("!test")
 @RequestMapping("/api")
 public class AuthController {
     private final UserService userService;
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
     private final CookieProperties cookieProperties;
+    private final MatrixProvisioningService matrixProvisioningService;
 
     public AuthController(
         UserService userService,
         JwtService jwtService,
         AuthenticationManager authenticationManager,
-        CookieProperties cookieProperties
+        CookieProperties cookieProperties,
+        MatrixProvisioningService matrixProvisioningService
     ) {
         this.userService = userService;
         this.jwtService = jwtService;
         this.authenticationManager = authenticationManager;
         this.cookieProperties = cookieProperties;
+        this.matrixProvisioningService = matrixProvisioningService;
     }
 
     @PostMapping("/login")
@@ -48,12 +55,12 @@ public class AuthController {
                 responseCode = "200",
                 content = @Content(
                     mediaType = "application/json",
-                    schema = @Schema(implementation = ResponseEntity.class)
+                    schema = @Schema(implementation = LoginResponse.class)
                 )
             )
         }
     )
-    public ResponseEntity<HttpStatus> login(@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
         try {
             Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(loginRequest.username(), loginRequest.password()));
@@ -70,7 +77,17 @@ public class AuthController {
                 .maxAge(Duration.ofHours(cookieProperties.getMaxAgeHours()))
                 .build();
 
-            return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
+            String matrixMessage = null;
+
+            if (!authenticatedUser.hasMatrixAccount()) {
+                MatrixProvisioningResponse matrixResponse = this.matrixProvisioningService.provisionAccount(
+                    this.userService.getByUsername(authenticatedUser.getUsername()));
+
+                matrixMessage = matrixResponse.message();
+            }
+
+            return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(new LoginResponse(matrixMessage));
         } catch (AuthenticationException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }

--- a/backend/src/main/java/cloudflight/integra/backend/security/LoginResponse.java
+++ b/backend/src/main/java/cloudflight/integra/backend/security/LoginResponse.java
@@ -1,0 +1,4 @@
+package cloudflight.integra.backend.security;
+
+public record LoginResponse (String matrixWarningMessage) {
+}

--- a/backend/src/main/java/cloudflight/integra/backend/user/CustomUserDetails.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/CustomUserDetails.java
@@ -29,4 +29,6 @@ public class CustomUserDetails implements UserDetails {
     public String getUsername() {
         return user.getUsername();
     }
+
+    public boolean hasMatrixAccount() { return user.getMatrixAccessToken() != null; }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/user/UserController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/UserController.java
@@ -1,5 +1,6 @@
 package cloudflight.integra.backend.user;
 
+import cloudflight.integra.backend.matrix.provisioning.MatrixProvisioningService;
 import cloudflight.integra.backend.tag.TagService;
 import cloudflight.integra.backend.user.model.User;
 import cloudflight.integra.backend.user.model.UserDto;
@@ -22,11 +23,18 @@ public class UserController {
     private final UserService userService;
     private final TagService tagService;
     private final UserMapper userMapper;
+    private final MatrixProvisioningService matrixProvisioningService;
 
-    public UserController(UserService userService, TagService tagService, UserMapper userMapper) {
+    public UserController(
+        UserService userService,
+        TagService tagService,
+        UserMapper userMapper,
+        MatrixProvisioningService matrixProvisioningService
+    ) {
         this.userService = userService;
         this.tagService = tagService;
         this.userMapper = userMapper;
+        this.matrixProvisioningService = matrixProvisioningService;
     }
 
     @PutMapping("/users/{username}/tags")
@@ -57,6 +65,9 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         User user = userService.getByUsername(userDetails.getUsername());
-        return ResponseEntity.ok(userMapper.toDto(user));
+
+        return ResponseEntity.ok(userMapper.toDto(user,
+            this.matrixProvisioningService.getMatrixUserId(user),
+            this.matrixProvisioningService.getTemporaryPassword(user)));
     }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/user/UserMapper.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/UserMapper.java
@@ -10,13 +10,15 @@ import java.util.stream.Collectors;
 @Component
 public class UserMapper {
 
-    public UserDto toDto(User user){
+    public UserDto toDto(User user, String matrixUserId, String matrixTemporaryPassword){
         return new UserDto(user.getId(),
             user.getUsername(),
             user.getEmail(),
             user.getRole(),
             user.getTags().stream().map(Tag::getId).collect(Collectors.toList()),
-            user.getJoinedDate());
+            user.getJoinedDate(),
+            matrixUserId,
+            matrixTemporaryPassword);
     }
 
 }

--- a/backend/src/main/java/cloudflight/integra/backend/user/UserService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/UserService.java
@@ -53,4 +53,10 @@ public class UserService implements UserDetailsService {
     }
 
     public User findByEmail(String email){ return userRepository.findByEmail(email); }
+
+    public void setMatrixAccount(String username, String accessToken) {
+        User user = userRepository.findByUsername(username);
+        user.setMatrixAccessToken(accessToken);
+        userRepository.save(user);
+    }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/user/model/User.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/model/User.java
@@ -32,6 +32,7 @@ public class User {
     private List<Tag> tags;
 
     private LocalDateTime joinedDate;
+    private String matrixAccessToken;
 
     public User() {}
 
@@ -42,7 +43,8 @@ public class User {
         String password,
         Role role,
         List<Tag> tags,
-        LocalDateTime joinedDate
+        LocalDateTime joinedDate,
+        String matrixAccessToken
     ) {
         this.id = id;
         this.username = username;
@@ -51,6 +53,7 @@ public class User {
         this.role = role;
         this.tags = tags;
         this.joinedDate = joinedDate;
+        this.matrixAccessToken = matrixAccessToken;
     }
 
     public UUID getId() {
@@ -102,6 +105,10 @@ public class User {
     public LocalDateTime getJoinedDate() { return joinedDate; }
 
     public void setJoinedDate(LocalDateTime joinedDate) { this.joinedDate = joinedDate; }
+
+    public String getMatrixAccessToken() { return matrixAccessToken; }
+
+    public void setMatrixAccessToken(String matrixAccessToken) { this.matrixAccessToken = matrixAccessToken; }
 
     @Override
     public boolean equals(Object o) {

--- a/backend/src/main/java/cloudflight/integra/backend/user/model/UserDto.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/model/UserDto.java
@@ -6,8 +6,24 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-public record UserDto(UUID id, String username, String email, Role role, List<Long> tagIds, LocalDateTime joinedDate) {
+public record UserDto(
+    UUID id,
+    String username,
+    String email,
+    Role role,
+    List<Long> tagIds,
+    LocalDateTime joinedDate,
+    String matrixUserId,
+    String matrixTemporaryPassword
+) {
     public UserDto(UUID id ,String username, String email) {
-        this(id, username, email,  null, null, null);
+        this(id,
+            username,
+            email,
+            null,
+            null,
+            null,
+            null,
+            null);
     }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -34,3 +34,7 @@ logging:
   level:
     org.flywaydb: INFO
 
+matrix:
+  server-name: ${MATRIX_SERVER_NAME:}
+  base-url: ${MATRIX_BASE_URL:http://localhost:8008}
+  registration-shared-secret: ${MATRIX_REGISTRATION_SHARED_SECRET:}

--- a/backend/src/main/resources/db/migration/V126__add_matrix_data_to_user.sql
+++ b/backend/src/main/resources/db/migration/V126__add_matrix_data_to_user.sql
@@ -1,0 +1,2 @@
+alter table users
+    add column matrix_access_token text

--- a/backend/src/test/resources/application.yaml
+++ b/backend/src/test/resources/application.yaml
@@ -28,3 +28,8 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
   default-produces-media-type: application/json
+
+matrix:
+  server-name: server
+  base-url: url
+  registration-shared-secret: secret

--- a/frontend/src/app/login/feature/login-page/login-page.ts
+++ b/frontend/src/app/login/feature/login-page/login-page.ts
@@ -23,9 +23,13 @@ export class LoginPage {
 
     protected onSubmit(request: LoginRequest) {
         this.authService.loginUser(request).subscribe({
-            next: async () => {
+            next: async (res) => {
                 await this.userDetailsService.loadCurrentUser();
                 this.toastService.showSuccess("Logged in successfully!");
+
+                if (res?.matrixWarningMessage) {
+                    this.toastService.showError(res.matrixWarningMessage);
+                }
 
                 setTimeout(() => {
                     this.router.navigate(['/home']).then(() => {

--- a/frontend/src/app/profile/feature/profile-page/profile-page.html
+++ b/frontend/src/app/profile/feature/profile-page/profile-page.html
@@ -19,7 +19,7 @@
     </p-card>
 } @else {
     <p-card [header]="user.username" class="min-h-[150px]">
-        <div class="flex flex-column gap-3">
+        <div class="flex flex-col gap-3">
             <div>
                 <p class="m-0 mb-3">
                     Email: <span class="italic">{{ user.email }}</span>
@@ -42,6 +42,22 @@
                     label="Add Location">
                 </p-button>
             </div>
+        </div>
+        <div class="mt-8">
+            <p class="font-semibold text-lg">
+                Matrix credentials
+            </p>
+            @if (user.matrixUserId) {
+                <p class="m-0">
+                    Matrix Account ID: <span class="italic">{{ user.matrixUserId }}</span>
+                </p>
+            }
+            @if (user.matrixTemporaryPassword) {
+                <p class="m-0 text-red-500">
+                    Matrix Temporary Password:
+                    <span class="italic font-semibold">{{ user.matrixTemporaryPassword }}</span>
+                </p>
+            }
         </div>
     </p-card>
 }


### PR DESCRIPTION
Added provisioning for Matrix accounts:
- set up Matrix homeserver secrets of name, url and registration shared secret
- added column in database for Matrix access token
- added rest client for creating Matrix accounts for users on the homeserver using the Synapse Admin API
- added MatrixProvisioningService for provisioning when user is logging in and doesn't have an account already and generating a temporary random password which is not saved in the database
- added message in response of login endpoint for displaying in frontend any errors related to Matrix homeserver and Matrix account creation while letting user to log in
- added section in user profile for displaying the Matrix credentials, user ID and temporary password

Refs: #126