### PR TITLE
feat(event): create matrix room on event creation

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/event/EventMapper.java
+++ b/backend/src/main/java/cloudflight/integra/backend/event/EventMapper.java
@@ -15,10 +15,18 @@ public class EventMapper {
             event.getStartTime(),
             event.getEndTime(),
             event.getLocation().getId(),
-            event.getHobbyGroup().getId());
+            event.getHobbyGroup().getId(),
+            event.getMatrixRoomId());
     }
 
     public Event toEntity(EventDto dto, Location location, HobbyGroup hobbyGroup) {
-        return new Event(dto.id(), dto.title(), dto.startTime(), dto.endTime(), location, hobbyGroup);
+        Event eventFomDto = new Event(dto.id(),
+            dto.title(),
+            dto.startTime(),
+            dto.endTime(),
+            location,
+            hobbyGroup);
+        eventFomDto.setMatrixRoomId(eventFomDto.getMatrixRoomId());
+        return eventFomDto;
     }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/event/EventService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/event/EventService.java
@@ -1,6 +1,7 @@
 package cloudflight.integra.backend.event;
 
 import cloudflight.integra.backend.event.model.Event;
+import cloudflight.integra.backend.matrix.api.MatrixRoomCreationRestClient;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -10,12 +11,19 @@ import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestClientException;
+
 @Service
 public class EventService {
     private final EventRepository repository;
+    private static final Logger logger = LoggerFactory.getLogger(EventService.class);
+    private final MatrixRoomCreationRestClient matrixRoomCreationRestClient;
 
-    public EventService(EventRepository repository) {
+    public EventService(EventRepository repository, MatrixRoomCreationRestClient matrixRoomCreationRestClient) {
         this.repository = repository;
+        this.matrixRoomCreationRestClient = matrixRoomCreationRestClient;
     }
 
     @Transactional(readOnly = true)
@@ -36,7 +44,14 @@ public class EventService {
     @Transactional
     public Event create(Event event) {
         event.setId(null);
-        return repository.save(event);
+        Event newEvent = repository.save(event);
+        try {
+            newEvent.setMatrixRoomId(matrixRoomCreationRestClient.createRoom(event.getTitle()));
+        }
+        catch ( RestClientException e){
+            logger.error("Failed to create Matrix room for event {}: {}", event.getTitle(), e.getMessage());
+        }
+        return newEvent;
     }
 
     @Transactional

--- a/backend/src/main/java/cloudflight/integra/backend/event/model/Event.java
+++ b/backend/src/main/java/cloudflight/integra/backend/event/model/Event.java
@@ -20,6 +20,7 @@ public class Event {
 
     @ManyToOne
     private HobbyGroup hobbyGroup;
+    private String matrixRoomId;
 
 
     public Event(
@@ -36,6 +37,8 @@ public class Event {
         this.endTime = endTime;
         this.hobbyGroup = hobbyGroup;
         this.location = location;
+        this.matrixRoomId = null;
+
     }
 
     public Event() {
@@ -88,4 +91,8 @@ public class Event {
     public void setHobbyGroup(HobbyGroup hobbyGroup) {
         this.hobbyGroup = hobbyGroup;
     }
+
+    public String getMatrixRoomId() { return this.matrixRoomId;}
+
+    public void setMatrixRoomId(String matrixRoomId) {this.matrixRoomId = matrixRoomId;}
 }

--- a/backend/src/main/java/cloudflight/integra/backend/event/model/EventDto.java
+++ b/backend/src/main/java/cloudflight/integra/backend/event/model/EventDto.java
@@ -9,6 +9,7 @@ public record EventDto(
     LocalDateTime startTime,
     LocalDateTime endTime,
     UUID locationId,
-    UUID hobbyGroupId
+    UUID hobbyGroupId,
+    String matrixRoomId
 ) {
 }

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixAuthRestClient.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixAuthRestClient.java
@@ -3,6 +3,7 @@ package cloudflight.integra.backend.matrix.api;
 import cloudflight.integra.backend.matrix.api.model.MatrixNonceResponse;
 import cloudflight.integra.backend.matrix.api.model.MatrixRegisterRequest;
 import cloudflight.integra.backend.matrix.api.model.MatrixRegisterResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -19,10 +20,10 @@ public class MatrixAuthRestClient {
     private final String sharedSecret;
 
     public MatrixAuthRestClient(
-        RestClient matrixRestClient,
+        @Qualifier("matrixRestClient") RestClient restClient,
         @Value("${matrix.registration-shared-secret}") String sharedSecret
     ) {
-        this.matrixRestClient = matrixRestClient;
+        this.matrixRestClient = restClient;
         this.sharedSecret = sharedSecret;
     }
 

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixRestClientConfig.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixRestClientConfig.java
@@ -12,10 +12,26 @@ import java.awt.*;
 public class MatrixRestClientConfig {
 
     @Bean
-    RestClient MatrixRestClient(RestClient.Builder builder, @Value("${matrix.base-url}")  String serverUrl) {
+    RestClient matrixRestClient(
+        RestClient.Builder builder,
+        @Value("${matrix.base-url}") String serverUrl
+    ) {
         return builder
             .baseUrl(serverUrl)
             .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    @Bean
+    RestClient matrixAdminRestClient(
+        RestClient.Builder builder,
+        @Value("${matrix.base-url}") String serverUrl,
+        @Value("${matrix.admin.token}") String adminToken
+    ) {
+        return builder
+            .baseUrl(serverUrl)
+            .defaultHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .defaultHeader("Authorization", "Bearer " + adminToken)
             .build();
     }
 }

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixRoomCreationRestClient.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/MatrixRoomCreationRestClient.java
@@ -1,0 +1,30 @@
+package cloudflight.integra.backend.matrix.api;
+
+import cloudflight.integra.backend.matrix.api.model.CreateRoomRequest;
+import cloudflight.integra.backend.matrix.api.model.RoomCreationContent;
+import cloudflight.integra.backend.matrix.api.model.MatrixRoomCreationResponseContent;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.Objects;
+
+@Service
+public class MatrixRoomCreationRestClient {
+
+    private final RestClient restClient;
+
+    public MatrixRoomCreationRestClient(@Qualifier("matrixAdminRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public String createRoom(String roomName) {
+        CreateRoomRequest newRoomRequest =
+            new CreateRoomRequest(new RoomCreationContent(false), roomName, "private_chat");
+        return Objects.requireNonNull(restClient.post()
+            .uri("/_matrix/client/v3/createRoom")
+            .body(newRoomRequest)
+            .retrieve()
+            .body(MatrixRoomCreationResponseContent.class)).roomId();
+    }
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/CreateRoomRequest.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/CreateRoomRequest.java
@@ -1,0 +1,10 @@
+package cloudflight.integra.backend.matrix.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CreateRoomRequest(
+    @JsonProperty("creation_content") RoomCreationContent roomCreationContent,
+    String name,
+    String preset
+) {
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/MatrixRoomCreationResponseContent.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/MatrixRoomCreationResponseContent.java
@@ -1,0 +1,7 @@
+package cloudflight.integra.backend.matrix.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MatrixRoomCreationResponseContent(
+    @JsonProperty("room_id") String roomId) {
+}

--- a/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/RoomCreationContent.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/api/model/RoomCreationContent.java
@@ -1,0 +1,8 @@
+package cloudflight.integra.backend.matrix.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record RoomCreationContent(
+    @JsonProperty("m.federate") Boolean federate
+) {
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -35,6 +35,8 @@ logging:
     org.flywaydb: INFO
 
 matrix:
+  admin:
+    token: ${MATRIX_ACCESS_TOKEN:}
   server-name: ${MATRIX_SERVER_NAME:}
   base-url: ${MATRIX_BASE_URL:http://localhost:8008}
   registration-shared-secret: ${MATRIX_REGISTRATION_SHARED_SECRET:}

--- a/backend/src/main/resources/db/migration/V124__add_matrix_room_to_event.sql
+++ b/backend/src/main/resources/db/migration/V124__add_matrix_room_to_event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE event ADD COLUMN matrix_room_id VARCHAR

--- a/backend/src/test/resources/application.yaml
+++ b/backend/src/test/resources/application.yaml
@@ -30,6 +30,8 @@ springdoc:
   default-produces-media-type: application/json
 
 matrix:
+  admin:
+    token: token
   server-name: server
   base-url: url
   registration-shared-secret: secret


### PR DESCRIPTION
added the database version and modified the event entity so it holds the id of the matrix room of the event. Created a rest client to handle the create room request to the synapse server. Modified the event service so it has an error logger and a matrix rest client. Modified the create method in the service, so it makes a request on the matrix client for a room and treated the case in which the creation of the room fails by logging the error

Refs: #124