### PR TITLE
security(BE): Enforce Roles

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/location/LocationController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/location/LocationController.java
@@ -59,7 +59,7 @@ public class LocationController {
         return locationMapper.toDto(locationService.getById(id));
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/admin/{id}")
     @Operation(
         summary = "Delete a Location",
         operationId = "deleteLocation",

--- a/backend/src/main/java/cloudflight/integra/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/cloudflight/integra/backend/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((authorize) -> authorize
             .requestMatchers("/api/login", "/api/register").permitAll()
+            .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
             .requestMatchers("/api/**").authenticated()
             .anyRequest().permitAll()
         );

--- a/backend/src/main/java/cloudflight/integra/backend/tag/TagController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/tag/TagController.java
@@ -61,7 +61,7 @@ public class TagController {
         return this.service.filterNormalizedLabel(value, pageable).map(this.mapper::toDto);
     }
 
-    @PostMapping()
+    @PostMapping("/admin")
     @Operation(
         summary = "Add a new Tag to the repository",
         operationId = "createNewTag",
@@ -80,7 +80,7 @@ public class TagController {
         return this.mapper.toDto(this.service.create(this.mapper.toEntity(dto)));
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("/admin/{id}")
     @Operation(
         summary = "Update an existing Tag from the repository",
         operationId = "updateTag",
@@ -99,7 +99,7 @@ public class TagController {
         return mapper.toDto(this.service.update(id, this.mapper.toEntity(dto)));
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/admin/{id}")
     @Operation(
         summary = "Delete an existing Tag from the repository",
         operationId = "deleteTag"

--- a/backend/src/main/java/cloudflight/integra/backend/user/CustomUserDetails.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/CustomUserDetails.java
@@ -17,7 +17,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().toString()));
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
     }
 
     @Override

--- a/frontend/src/app/home/feature/home-page/home-page.ts
+++ b/frontend/src/app/home/feature/home-page/home-page.ts
@@ -39,8 +39,6 @@ export class HomePage implements OnInit {
     ngOnInit(): void {
         this.getHobbyGroups(0)
         this.loading.set(true)
-
-
     }
 
     ngAfterViewInit(): void {

--- a/frontend/src/app/sidebar/feature/sidebar/sidebar.ts
+++ b/frontend/src/app/sidebar/feature/sidebar/sidebar.ts
@@ -36,7 +36,7 @@ export class Sidebar {
     });
 
     logout() {
-        localStorage.removeItem('userToken');
+        document.cookie = "jwt=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
         this.router.navigate(['/login']);
     }
 }


### PR DESCRIPTION
- all admin controllers/endpoints are prefixed with /admin (only some endpoints in locations and tags suffer this)
- spring security restricts all routes matching /admin/** to users with the ROLE_ADMIN role
- authenticated users without ROLE_ADMIN receive a 403 Forbidden response
- unauthenticated users receive a 401 unauthorized response

Refs: #136