### PR TITLE
feat(HobbyGroup-Location): HobbyGroup Linked to Location

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/databaseseed/DatabaseSeedService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/databaseseed/DatabaseSeedService.java
@@ -190,6 +190,8 @@ public class DatabaseSeedService {
             hobbyGroup.setDescription(truncate(faker.yoda().quote()));
             hobbyGroup.setRadiusKm(faker.number().numberBetween(0, 10));
             hobbyGroup.setOwner(user);
+            hobbyGroup.setGroupLocation(locationService.getAllList()
+                .get(faker.random().nextInt(locationService.getAllList().size())));
             hobbyGroupService.create(hobbyGroup);
             i--;
         }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupController.java
@@ -2,6 +2,8 @@ package cloudflight.integra.backend.hobbyGroup;
 
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroupDto;
+import cloudflight.integra.backend.location.LocationService;
+import cloudflight.integra.backend.location.model.Location;
 import cloudflight.integra.backend.tag.TagService;
 import cloudflight.integra.backend.user.UserService;
 import cloudflight.integra.backend.user.model.User;
@@ -25,17 +27,20 @@ public class HobbyGroupController {
     private final TagService tagService;
     private final HobbyGroupMapper mapper;
     private final UserService userService;
+    private final LocationService locationService;
 
     public HobbyGroupController(
         HobbyGroupService service,
         TagService tagService,
         HobbyGroupMapper mapper,
-        UserService userService
+        UserService userService,
+        LocationService locationService
     ) {
         this.hobbyGroupService = service;
         this.tagService = tagService;
         this.mapper = mapper;
         this.userService = userService;
+        this.locationService = locationService;
     }
 
     @Operation(
@@ -43,7 +48,12 @@ public class HobbyGroupController {
         operationId = "getAllHobbyGroups"
     )
     @GetMapping
-    public Page<HobbyGroupDto> getAll(Pageable pageable) {
+    public Page<HobbyGroupDto> getAll(@RequestParam(required = false) UUID locationId,Pageable pageable) {
+        if(locationId != null){
+            Location groupLocation = locationService.getById(locationId);
+            return hobbyGroupService.getAllByLocation(groupLocation, pageable)
+                .map(group -> mapper.toDto(group, tagService.getIdsFromTags(group.getTags())));
+        }
         return hobbyGroupService.getAll(pageable)
             .map(group -> mapper.toDto(group, tagService.getIdsFromTags(group.getTags())));
     }
@@ -57,6 +67,7 @@ public class HobbyGroupController {
         return hobbyGroupService.filterByName(name, pageable)
             .map(group -> mapper.toDto(group, tagService.getIdsFromTags(group.getTags())));
     }
+
 
     @GetMapping("/{id}")
     @Operation(
@@ -98,7 +109,8 @@ public class HobbyGroupController {
         HobbyGroup createHobbyGroup = hobbyGroupService.create(mapper.toEntity(
             groupDto,
             tagService.getTagsFromIds(groupDto.tagIds()),
-            owner)
+            owner,
+            locationService.getById(groupDto.groupLocationId()))
         );
         return mapper.toDto(createHobbyGroup, groupDto.tagIds());
     }
@@ -125,7 +137,8 @@ public class HobbyGroupController {
         HobbyGroup updateHobbyGroup = hobbyGroupService.update(id, mapper.toEntity(
             groupDto,
             tagService.getTagsFromIds(groupDto.tagIds()),
-            owner));
+            owner,
+            locationService.getById(groupDto.groupLocationId())));
 
         return mapper.toDto(updateHobbyGroup, groupDto.tagIds());
     }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupMapper.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupMapper.java
@@ -2,6 +2,7 @@ package cloudflight.integra.backend.hobbyGroup;
 
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroupDto;
+import cloudflight.integra.backend.location.model.Location;
 import cloudflight.integra.backend.tag.model.Tag;
 import cloudflight.integra.backend.user.model.User;
 import org.mapstruct.Mapper;
@@ -14,13 +15,16 @@ import java.util.UUID;
 public interface HobbyGroupMapper {
     @Mapping(target = "ownerID", source = "group.owner.id")
     @Mapping(target = "memberIds", source = "group.members")
+    @Mapping(target = "groupLocationId", source = "group.groupLocation.id")
     HobbyGroupDto toDto(HobbyGroup group, List<Long> tagIds);
 
     @Mapping(target = "id", source = "groupDto.id")
+    @Mapping(target = "name", source = "groupDto.name")
     @Mapping(target = "tags", source = "tags")
     @Mapping(target = "owner", source = "owner")
     @Mapping(target = "members", source = "owner")
-    HobbyGroup toEntity(HobbyGroupDto groupDto, List<Tag> tags, User owner);
+    @Mapping(target = "groupLocation", source = "location")
+    HobbyGroup toEntity(HobbyGroupDto groupDto, List<Tag> tags, User owner, Location location);
 
     default UUID mapMember(User member) {
         return member.getId();

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupRepository.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupRepository.java
@@ -1,6 +1,7 @@
 package cloudflight.integra.backend.hobbyGroup;
 
 import cloudflight.integra.backend.hobbyGroup.model.HobbyGroup;
+import cloudflight.integra.backend.location.model.Location;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ import java.util.UUID;
 @Repository
 public interface HobbyGroupRepository extends JpaRepository<HobbyGroup, UUID> {
     Page<HobbyGroup> findByNameContainingIgnoreCase(String name, Pageable pageable);
+
+    Page<HobbyGroup> findByGroupLocation(Location location, Pageable pageable);
 }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupService.java
@@ -44,6 +44,11 @@ public class HobbyGroupService {
         return repository.findById(id).orElseThrow();
     }
 
+    @Transactional(readOnly = true)
+    public Page<HobbyGroup> getAllByLocation(Location location, Pageable pageable) {
+        return repository.findByGroupLocation(location, pageable);
+    }
+
     @Transactional
     public HobbyGroup create(HobbyGroup group) {
         group.setId(null);
@@ -94,4 +99,5 @@ public class HobbyGroupService {
         repository.save(hobbyGroup);
         return hobbyGroup;
     }
+
 }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroup.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroup.java
@@ -1,5 +1,6 @@
 package cloudflight.integra.backend.hobbyGroup.model;
 
+import cloudflight.integra.backend.location.model.Location;
 import cloudflight.integra.backend.tag.model.Tag;
 import cloudflight.integra.backend.user.model.User;
 import jakarta.persistence.*;
@@ -27,6 +28,10 @@ public class HobbyGroup {
     @JoinColumn(name = "owner_id")
     private User owner;
 
+    @OneToOne
+    @JoinColumn(name="group_location_id")
+    private Location groupLocation;
+
     @ManyToMany
     @JoinTable(
         name = "group_members",
@@ -42,7 +47,8 @@ public class HobbyGroup {
         String description,
         double radiusKm,
         List<Tag> tags,
-        User owner
+        User owner,
+        Location groupLocation
     ) {
         this.id = id;
         this.name = name;
@@ -51,6 +57,7 @@ public class HobbyGroup {
         this.tags = tags;
         this.owner = owner;
         this.members.add(owner);
+        this.groupLocation = groupLocation;
     }
 
     public HobbyGroup() {
@@ -113,6 +120,15 @@ public class HobbyGroup {
     public HobbyGroup setOwner(User owner) {
         this.owner = owner;
         return this;
+    }
+
+    public HobbyGroup setGroupLocation(Location groupLocation) {
+        this.groupLocation = groupLocation;
+        return this;
+    }
+
+    public Location getGroupLocation() {
+        return groupLocation;
     }
 
     public void setMembers(List<User> members) {

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroupDto.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroupDto.java
@@ -1,5 +1,7 @@
 package cloudflight.integra.backend.hobbyGroup.model;
 
+import cloudflight.integra.backend.location.model.Location;
+
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
@@ -14,6 +16,7 @@ public record HobbyGroupDto(
     double radiusKm,
     List<Long> tagIds,
     UUID ownerID,
-    List<UUID> memberIds
+    List<UUID> memberIds,
+    UUID groupLocationId
 ) {
 }

--- a/backend/src/main/java/cloudflight/integra/backend/location/LocationController.java
+++ b/backend/src/main/java/cloudflight/integra/backend/location/LocationController.java
@@ -54,7 +54,12 @@ public class LocationController {
         return locationService.getAll(pageable).map(locationMapper::toDto);
     }
 
+
     @GetMapping("/{id}")
+    @Operation(
+        operationId= "getLocationById",
+        summary= "Get location by id"
+    )
     public LocationDto getById(@PathVariable UUID id) {
         return locationMapper.toDto(locationService.getById(id));
     }

--- a/backend/src/main/resources/db/migration/V87__hobbygroup_table_with_location.sql
+++ b/backend/src/main/resources/db/migration/V87__hobbygroup_table_with_location.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hobby_group ADD COLUMN group_location_id UUID,
+ADD CONSTRAINT fk_hobby_group_location FOREIGN KEY (group_location_id) REFERENCES location (id);

--- a/frontend/src/app/home/feature/home-page/home-page.html
+++ b/frontend/src/app/home/feature/home-page/home-page.html
@@ -2,17 +2,24 @@
     <div class="w-full max-w-150 order-2 md:order-1">
         <h2 class="text-2xl whitespace-nowrap font-bold mb-6 md:text-3xl">Hobby Groups</h2>
         <div class="flex flex-col gap-6 mt-4">
-            @if (!loading()) {
+            @if (uiState() === 'loading') {
+                @for (i of [1,2,3,4]; track i) {
+                    <app-hobby-group-card [loading]="true" [hobbyGroupDto]="{ name: '', description: '' }"/>
+                }
+            }
+
+            @else if (uiState() === 'data') {
                 @for (group of filteredHobbyGroups(); track group.id) {
-                    <app-hobby-group-card (groupDeleted)="onGroupDeleted()"
-                        (groupUpdated)="onGroupUpdated()"
+                    <app-hobby-group-card
                         [hobbyGroupDto]="group"
-                        [loading]="false"/>
+                        [loading]="false"
+                        (groupDeleted)="onGroupDeleted()"
+                        (groupUpdated)="onGroupUpdated()"/>
                 }
-            } @else () {
-                @for (i of [1, 2, 3, 4, 5]; track i) {
-                    <app-hobby-group-card [loading]="true"/>
-                }
+            }
+
+            @else {
+                <app-empty-state-card/>
             }
             <div #scrollAnchor class="h-20 w-full flex justify-center items-center">
 

--- a/frontend/src/app/home/feature/home-page/home-page.ts
+++ b/frontend/src/app/home/feature/home-page/home-page.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, ElementRef, inject, OnInit, signal, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, inject, OnInit, signal, ViewChild, effect, computed} from '@angular/core';
 import {HobbyGroupCard} from "../../ui/hobby-group-card/hobby-group-card";
 import {HobbyGroupControllerService} from "@app/api/api/hobbyGroupController.service";
 import {HobbyGroupDto} from "@app/api/model/hobbyGroupDto";
@@ -8,8 +8,11 @@ import {Searchbar} from "../../../searchbar/searchbar";
 import {Pageable} from "@app/api/model/pageable";
 import {PageHobbyGroupDto} from "@app/api/model/pageHobbyGroupDto";
 import {Button} from "primeng/button";
+import {UserDetailsService} from '../../../services/UserDetailsService/user-details-service';
+import {EmptyStateCard} from '../../ui/empty-state-card/empty-state-card';
+
+type State = 'loading' | 'data' | 'empty';
 import * as L from 'leaflet';
-import{UserDetailsService} from "../../../services/UserDetailsService/user-details-service";
 import{EventControllerService} from "@app/api/api/eventController.service";
 import {EventMapDto} from "@app/api/model/eventMapDto";
 
@@ -21,6 +24,7 @@ import {EventMapDto} from "@app/api/model/eventMapDto";
         CreateHobbyGroup,
         Searchbar,
         Button,
+        EmptyStateCard,
     ],
     templateUrl: './home-page.html',
     standalone: true,
@@ -37,6 +41,8 @@ export class HomePage implements OnInit,AfterViewInit {
     searchQuery = signal<string>('');
     filteredHobbyGroups = signal<HobbyGroupDto[]>([]);
 
+
+
     totalRecords = signal<number>(0);
     loading = signal<boolean>(false);
     currentPage = signal<number>(0);
@@ -46,9 +52,22 @@ export class HomePage implements OnInit,AfterViewInit {
 
     @ViewChild('scrollAnchor') scrollAnchor!: ElementRef;
 
+
+    uiState = computed<State>(() => {
+        if (this.loading()) return 'loading';
+        return this.filteredHobbyGroups().length == 0 ? 'empty' : 'data';
+    });
+
     ngOnInit(): void {
-        this.getHobbyGroups(0)
-        this.loading.set(true)
+    }
+
+    constructor() {
+        effect(() => {
+            const locationId = this.userDetailsService.selectedLocation()?.id;
+            if (locationId) {
+                this.getHobbyGroupsByLocation(0);
+            }
+        });
     }
     ngAfterViewInit(): void {
         this.initMap();
@@ -129,6 +148,27 @@ export class HomePage implements OnInit,AfterViewInit {
             });
     }
 
+    getHobbyGroupsByLocation(page: number) {
+        this.loading.set(true);
+        const locationId = this.userDetailsService.selectedLocation()?.id;
+        this.hobbyGroupService.getAllHobbyGroups({ size: 4, page: page },locationId)
+            .subscribe({
+                next: (response) => {
+                    const newItems = response.content ?? [];
+                    this.totalRecords.set(response.totalElements ?? 0);
+
+                    if (page === 0) {
+                        this.hobbyGroups.set(newItems);
+                    } else {
+                        this.hobbyGroups.update(prev => [...prev, ...newItems]);
+                    }
+                    this.filteredHobbyGroups.set(this.hobbyGroups());
+                    this.loading.set(false);
+                },
+                error: () => this.loading.set(false)
+            });
+    }
+
     getFilteredHobbyGroups(page: number) {
         this.loading.set(true);
         this.hobbyGroupService.filterAllHobbyGroupsByName(this.searchQuery().trim(), { size: 4, page: page })
@@ -154,7 +194,7 @@ export class HomePage implements OnInit,AfterViewInit {
         this.currentPage.set(0);
         this.hobbyGroups.set([]);
         if (!searchTerm || searchTerm.trim() === '') {
-            this.getHobbyGroups(0);
+            this.getHobbyGroupsByLocation(0);
             return;
         }
         const pageable: Pageable = { page: 0 };

--- a/frontend/src/app/home/ui/create-hobby-group/create-hobby-group.ts
+++ b/frontend/src/app/home/ui/create-hobby-group/create-hobby-group.ts
@@ -11,6 +11,7 @@ import {Message} from "primeng/message";
 import {MultiSelect} from "primeng/multiselect";
 import {Button} from "primeng/button";
 import {ToastService} from "../../../toast-service/toast-service";
+import {UserDetailsService} from '../../../services/UserDetailsService/user-details-service';
 
 @Component({
     selector: 'app-create-hobby-group',
@@ -29,6 +30,7 @@ export class CreateHobbyGroup {
     hobbyGroupService = inject(HobbyGroupControllerService);
     visible = signal<boolean>(false);
     toastService = inject(ToastService);
+    userDetailsService = inject(UserDetailsService);
 
     refreshHobbyGroup = output<void>()
 
@@ -36,7 +38,8 @@ export class CreateHobbyGroup {
         name: "",
         description: "",
         radiusKm: 10,
-        tagIds: []
+        tagIds: [],
+        groupLocationId: this.userDetailsService.selectedLocation()?.id
     }
     tagService = inject(TagControllerService)
     tags = signal<TagDto[]>([]);
@@ -67,6 +70,7 @@ export class CreateHobbyGroup {
                         description: "",
                         radiusKm: 10,
                         tagIds: [],
+                        groupLocationId: this.userDetailsService.selectedLocation()?.id
                     };
                 },
                 error: (err) => {

--- a/frontend/src/app/home/ui/empty-state-card/empty-state-card.html
+++ b/frontend/src/app/home/ui/empty-state-card/empty-state-card.html
@@ -1,0 +1,12 @@
+<p-card class="min-h-[200px]">
+    <ng-template #title>
+        <h3>
+            No HobbyGroups Found!
+        </h3>
+    </ng-template>
+
+    <p class="mt-6">
+        Please select a different location or create a group yourself!
+    </p>
+
+</p-card>

--- a/frontend/src/app/home/ui/empty-state-card/empty-state-card.ts
+++ b/frontend/src/app/home/ui/empty-state-card/empty-state-card.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+import {Card} from 'primeng/card';
+
+@Component({
+    selector: 'app-empty-state-card',
+    imports: [
+        Card
+    ],
+    templateUrl: './empty-state-card.html',
+})
+export class EmptyStateCard {
+
+}

--- a/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.html
+++ b/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.html
@@ -35,7 +35,7 @@
 
     <p-card class="min-h-[200px]">
         <ng-template #title>
-            <h3>{{ hobbyGroupDto()?.name }}</h3>
+            <h3>{{ hobbyGroupDto()?.name }} | {{ groupLocation()?.name }}</h3>
         </ng-template>
 
         <p>
@@ -44,7 +44,7 @@
 
         <ng-template #footer>
             <div class="flex flex-row justify-between items-center">
-                <div class="flex flex-shrink-0 whitespace-nowrap">
+                <div class="flex flex-shrink-0 whitespace-nowrap justify-between ">
                     <p-avatar class="mr-2" icon="pi pi-user" shape="circle"/>
                     <span>User Name</span>
                 </div>

--- a/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.ts
+++ b/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.ts
@@ -1,4 +1,4 @@
-import {Component, computed, inject, input, output} from '@angular/core';
+import {Component, computed, inject, input, OnInit, output, signal} from '@angular/core';
 import {Card} from "primeng/card";
 import {Avatar} from "primeng/avatar";
 import {Chip} from "primeng/chip";
@@ -12,6 +12,8 @@ import {HobbyGroupControllerService} from "@app/api/api/hobbyGroupController.ser
 import {ToastService} from "../../../toast-service/toast-service";
 import {DeleteHobbyGroup} from "../delete-hobby-group/delete-hobby-group";
 import {Skeleton} from "primeng/skeleton";
+import {LocationControllerService} from '@app/api/api/locationController.service';
+import {LocationDto} from '@app/api/model/locationDto';
 
 @Component({
     selector: 'app-hobby-group-card',
@@ -26,16 +28,21 @@ import {Skeleton} from "primeng/skeleton";
     standalone: true,
     templateUrl: './hobby-group-card.html'
 })
-export class HobbyGroupCard {
+export class HobbyGroupCard implements OnInit {
 
     loading = input<boolean>(true);
     hobbyGroupDto = input<HobbyGroupDto>()
     hobbyGroupService = inject(HobbyGroupControllerService);
     tagService = inject(TagControllerService)
     userDetailsService = inject(UserDetailsService);
+    locationService = inject(LocationControllerService);
     groupUpdated = output<void>();
     toastService = inject(ToastService);
     groupDeleted = output<void>();
+    groupLocation = signal<LocationDto | null>(null);
+
+
+
 
     isMember = computed(() =>
         (this.hobbyGroupDto()?.memberIds as unknown as string[])
@@ -44,6 +51,21 @@ export class HobbyGroupCard {
     isOwner = computed(() =>
         this.hobbyGroupDto()?.ownerID === this.userDetailsService.getCurrentUser()?.id
     );
+
+    ngOnInit() {
+        const group = this.hobbyGroupDto();
+        if(group && group.groupLocationId != null)
+            this.setGroupLocation();
+    }
+
+    private setGroupLocation() {
+        this.locationService
+            .getLocationById(this.hobbyGroupDto()?.groupLocationId!)
+            .subscribe(location => {
+                this.groupLocation.set(location);
+            });
+    }
+
     private tags = toObservable(this.hobbyGroupDto).pipe(
         switchMap(group => {
             const ids = group?.tagIds;

--- a/frontend/src/app/services/UserDetailsService/user-details-service.ts
+++ b/frontend/src/app/services/UserDetailsService/user-details-service.ts
@@ -33,9 +33,10 @@ export class UserDetailsService {
                     const match = this.userLocations().find(i => i.id === prevLoc.id);
                     if (match) {
                         this.selectedLocation.set(match);
-                    } else {
-                        this.selectedLocation.set(this.userLocations()[0]);
                     }
+                } else if(this.userLocations().length > 0){
+                    this.selectedLocation.set(this.userLocations()[0]);
+                    console.log("selectedLocation")
                 }
                 this.loadingLocations.set(false);
             },


### PR DESCRIPTION
- Changed backend to properly link hobbygroup to location with a fk constraint, updated service and controller to match the new functionality
- Homepage now behaves as intended in the ticket as it now filters by the user location selected on the profile on empty search query, and behave the same as before when searching, which is giving you the entire list that matches your search
- Empty state is done as smooth as I could think of with a UIState computed variable
- Seeding also updated to fit Location into HobbyGroup

Refs: #87