### PR TITLE
feat(HobbyGroup): Add Username to HobbyGroupCards

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupMapper.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/HobbyGroupMapper.java
@@ -5,6 +5,7 @@ import cloudflight.integra.backend.hobbyGroup.model.HobbyGroupDto;
 import cloudflight.integra.backend.location.model.Location;
 import cloudflight.integra.backend.tag.model.Tag;
 import cloudflight.integra.backend.user.model.User;
+import cloudflight.integra.backend.user.model.UserSummaryDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -13,7 +14,7 @@ import java.util.UUID;
 
 @Mapper(componentModel = "spring")
 public interface HobbyGroupMapper {
-    @Mapping(target = "ownerID", source = "group.owner.id")
+    @Mapping(target = "owner", source = "group.owner")
     @Mapping(target = "memberIds", source = "group.members")
     @Mapping(target = "groupLocationId", source = "group.groupLocation.id")
     HobbyGroupDto toDto(HobbyGroup group, List<Long> tagIds);
@@ -26,6 +27,10 @@ public interface HobbyGroupMapper {
     @Mapping(target = "groupLocation", source = "location")
     HobbyGroup toEntity(HobbyGroupDto groupDto, List<Tag> tags, User owner, Location location);
 
+    default UserSummaryDto map(User user) {
+        if(user == null) return null;
+        return new UserSummaryDto(user.getId(), user.getUsername());
+    }
     default UUID mapMember(User member) {
         return member.getId();
     }

--- a/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroupDto.java
+++ b/backend/src/main/java/cloudflight/integra/backend/hobbyGroup/model/HobbyGroupDto.java
@@ -1,5 +1,7 @@
 package cloudflight.integra.backend.hobbyGroup.model;
 
+import cloudflight.integra.backend.user.model.UserSummaryDto;
+
 import cloudflight.integra.backend.location.model.Location;
 
 import jakarta.validation.constraints.NotBlank;
@@ -15,7 +17,7 @@ public record HobbyGroupDto(
     String description,
     double radiusKm,
     List<Long> tagIds,
-    UUID ownerID,
+    UserSummaryDto owner,
     List<UUID> memberIds,
     UUID groupLocationId
 ) {

--- a/backend/src/main/java/cloudflight/integra/backend/user/model/UserSummaryDto.java
+++ b/backend/src/main/java/cloudflight/integra/backend/user/model/UserSummaryDto.java
@@ -1,0 +1,8 @@
+package cloudflight.integra.backend.user.model;
+
+import java.util.UUID;
+
+public record UserSummaryDto(
+    UUID id,
+    String username
+) {}

--- a/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.html
+++ b/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.html
@@ -46,7 +46,7 @@
             <div class="flex flex-row justify-between items-center">
                 <div class="flex flex-shrink-0 whitespace-nowrap justify-between ">
                     <p-avatar class="mr-2" icon="pi pi-user" shape="circle"/>
-                    <span>User Name</span>
+                    <span>{{ hobbyGroupDto()?.owner?.username }}</span>
                 </div>
 
                 <div class="flex flex-row flex-wrap gap-2 justify-end">

--- a/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.ts
+++ b/frontend/src/app/home/ui/hobby-group-card/hobby-group-card.ts
@@ -14,6 +14,7 @@ import {DeleteHobbyGroup} from "../delete-hobby-group/delete-hobby-group";
 import {Skeleton} from "primeng/skeleton";
 import {LocationControllerService} from '@app/api/api/locationController.service';
 import {LocationDto} from '@app/api/model/locationDto';
+import {UserControllerService} from '@app/api/api/userController.service';
 
 @Component({
     selector: 'app-hobby-group-card',
@@ -35,6 +36,7 @@ export class HobbyGroupCard implements OnInit {
     hobbyGroupService = inject(HobbyGroupControllerService);
     tagService = inject(TagControllerService)
     userDetailsService = inject(UserDetailsService);
+    userControllerService = inject(UserControllerService);
     locationService = inject(LocationControllerService);
     groupUpdated = output<void>();
     toastService = inject(ToastService);
@@ -44,12 +46,14 @@ export class HobbyGroupCard implements OnInit {
 
 
 
+
+
     isMember = computed(() =>
         (this.hobbyGroupDto()?.memberIds as unknown as string[])
             ?.includes(this.userDetailsService.getCurrentUser()?.id ?? '')
     );
     isOwner = computed(() =>
-        this.hobbyGroupDto()?.ownerID === this.userDetailsService.getCurrentUser()?.id
+        this.hobbyGroupDto()?.owner?.id === this.userDetailsService.getCurrentUser()?.id
     );
 
     ngOnInit() {


### PR DESCRIPTION
- HobbyGroupDto now uses a new userSummaryDto that is composed of both the id and the username for ease of access
- Frontend now properly displays creator username on hbc

Refs: #152