### PR TITLE
fix(Matrix): fixed matrix account creation request

### DIFF
--- a/backend/src/main/java/cloudflight/integra/backend/matrix/provisioning/MatrixProvisioningService.java
+++ b/backend/src/main/java/cloudflight/integra/backend/matrix/provisioning/MatrixProvisioningService.java
@@ -65,10 +65,13 @@ public class MatrixProvisioningService {
 
         } catch (RestClientResponseException e) {
             HttpStatusCode errorCode = e.getStatusCode();
+            String responseBody = e.getResponseBodyAsString();
             if (errorCode.value() == 409) {
                 return MatrixProvisioningResponse.warn("Matrix account already exists for this username");
             }
-
+            if (errorCode.value() == 400 && responseBody.contains("M_USER_IN_USE")) {
+                return MatrixProvisioningResponse.ok();
+            }
             return MatrixProvisioningResponse.warn("Matrix homeserver rejected request");
         }
     }


### PR DESCRIPTION
The problem: we had a particular case, in which an account was already made for a user and the synapse server sent back the error with the code: 400. This was not treated in particular, so it was considered by our rest client an error from the synapse server and because of that  error warning "The matrix server rejected the request" was shown on screen.

I modified the code, so we treat the 400 error code differently, so the user no longer sees an error.

The creation of the room was working, so nothing had to be changed there

Refs: #156